### PR TITLE
Switch upstream dependency to io.mobilitydata.transit:gtfs-realtime-bindings:0.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.transit</groupId>
+      <groupId>io.mobilitydata.transit</groupId>
       <artifactId>gtfs-realtime-bindings</artifactId>
-      <version>0.0.4</version>
+      <version>0.0.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.11.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/google/transit/realtime/GtfsRealtimeLIRR.java
+++ b/src/main/java/com/google/transit/realtime/GtfsRealtimeLIRR.java
@@ -38,8 +38,14 @@ package com.google.transit.realtime;
 public final class GtfsRealtimeLIRR {
   private GtfsRealtimeLIRR() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
     registry.add(com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate.track);
+  }
+
+  public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   public interface MtaStopTimeUpdateOrBuilder extends
       // @@protoc_insertion_point(interface_extends:transit_realtime.MtaStopTimeUpdate)
@@ -48,37 +54,38 @@ public final class GtfsRealtimeLIRR {
   /**
    * Protobuf type {@code transit_realtime.MtaStopTimeUpdate}
    */
-  public static final class MtaStopTimeUpdate extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class MtaStopTimeUpdate extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.MtaStopTimeUpdate)
       MtaStopTimeUpdateOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use MtaStopTimeUpdate.newBuilder() to construct.
-    private MtaStopTimeUpdate(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private MtaStopTimeUpdate(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private MtaStopTimeUpdate(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final MtaStopTimeUpdate defaultInstance;
-    public static MtaStopTimeUpdate getDefaultInstance() {
-      return defaultInstance;
+    private MtaStopTimeUpdate() {
     }
 
-    public MtaStopTimeUpdate getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new MtaStopTimeUpdate();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private MtaStopTimeUpdate(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -90,8 +97,8 @@ public final class GtfsRealtimeLIRR {
               done = true;
               break;
             default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
               break;
@@ -102,7 +109,7 @@ public final class GtfsRealtimeLIRR {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -113,31 +120,16 @@ public final class GtfsRealtimeLIRR {
       return com.google.transit.realtime.GtfsRealtimeLIRR.internal_static_transit_realtime_MtaStopTimeUpdate_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeLIRR.internal_static_transit_realtime_MtaStopTimeUpdate_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate.class, com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<MtaStopTimeUpdate> PARSER =
-        new com.google.protobuf.AbstractParser<MtaStopTimeUpdate>() {
-      public MtaStopTimeUpdate parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MtaStopTimeUpdate(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<MtaStopTimeUpdate> getParserForType() {
-      return PARSER;
-    }
-
-    private void initFields() {
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -147,30 +139,60 @@ public final class GtfsRealtimeLIRR {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate other = (com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -194,46 +216,59 @@ public final class GtfsRealtimeLIRR {
     }
     public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -241,7 +276,7 @@ public final class GtfsRealtimeLIRR {
      * Protobuf type {@code transit_realtime.MtaStopTimeUpdate}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.MtaStopTimeUpdate)
         com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdateOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -249,7 +284,8 @@ public final class GtfsRealtimeLIRR {
         return com.google.transit.realtime.GtfsRealtimeLIRR.internal_static_transit_realtime_MtaStopTimeUpdate_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeLIRR.internal_static_transit_realtime_MtaStopTimeUpdate_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -262,36 +298,33 @@ public final class GtfsRealtimeLIRR {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeLIRR.internal_static_transit_realtime_MtaStopTimeUpdate_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate build() {
         com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate result = buildPartial();
         if (!result.isInitialized()) {
@@ -300,12 +333,46 @@ public final class GtfsRealtimeLIRR {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate buildPartial() {
         com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate result = new com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate(this);
         onBuilt();
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate)other);
@@ -317,14 +384,17 @@ public final class GtfsRealtimeLIRR {
 
       public Builder mergeFrom(com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate other) {
         if (other == com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate.getDefaultInstance()) return this;
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -334,7 +404,7 @@ public final class GtfsRealtimeLIRR {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -342,23 +412,64 @@ public final class GtfsRealtimeLIRR {
         }
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.MtaStopTimeUpdate)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.MtaStopTimeUpdate)
+    private static final com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate DEFAULT_INSTANCE;
     static {
-      defaultInstance = new MtaStopTimeUpdate(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.MtaStopTimeUpdate)
+    public static com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<MtaStopTimeUpdate>
+        PARSER = new com.google.protobuf.AbstractParser<MtaStopTimeUpdate>() {
+      @java.lang.Override
+      public MtaStopTimeUpdate parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MtaStopTimeUpdate(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MtaStopTimeUpdate> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MtaStopTimeUpdate> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeLIRR.MtaStopTimeUpdate getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
     public static final int TRACK_FIELD_NUMBER = 1005;
     /**
-     * <code>extend .transit_realtime.TripUpdate.StopTimeUpdate { ... }</code>
-     *
      * <pre>
      *can add additional fields here without having to extend StopTimeUpdate again
      * </pre>
+     *
+     * <code>extend .transit_realtime.TripUpdate.StopTimeUpdate { ... }</code>
      */
     public static final
       com.google.protobuf.GeneratedMessage.GeneratedExtension<
@@ -373,15 +484,15 @@ public final class GtfsRealtimeLIRR {
 
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_MtaStopTimeUpdate_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_MtaStopTimeUpdate_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
   }
-  private static com.google.protobuf.Descriptors.FileDescriptor
+  private static  com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
     java.lang.String[] descriptorData = {
@@ -392,23 +503,15 @@ public final class GtfsRealtimeLIRR {
       "t_realtime.TripUpdate.StopTimeUpdate\030\355\007 " +
       "\001(\tB\035\n\033com.google.transit.realtime"
     };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
+    descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.transit.realtime.GtfsRealtime.getDescriptor(),
-        }, assigner);
+        });
     internal_static_transit_realtime_MtaStopTimeUpdate_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_transit_realtime_MtaStopTimeUpdate_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_MtaStopTimeUpdate_descriptor,
         new java.lang.String[] { });
     com.google.transit.realtime.GtfsRealtime.getDescriptor();

--- a/src/main/java/com/google/transit/realtime/GtfsRealtimeMNR.java
+++ b/src/main/java/com/google/transit/realtime/GtfsRealtimeMNR.java
@@ -38,49 +38,61 @@ package com.google.transit.realtime;
 public final class GtfsRealtimeMNR {
   private GtfsRealtimeMNR() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
     registry.add(com.google.transit.realtime.GtfsRealtimeMNR.mnrStopTimeUpdate);
+  }
+
+  public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   public interface MnrStopTimeUpdateOrBuilder extends
       // @@protoc_insertion_point(interface_extends:transit_realtime.MnrStopTimeUpdate)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional string track = 1;</code>
-     *
      * <pre>
      *can add additional fields here without having to //extend StopTimeUpdate again
      * </pre>
+     *
+     * <code>optional string track = 1;</code>
+     * @return Whether the track field is set.
      */
     boolean hasTrack();
     /**
-     * <code>optional string track = 1;</code>
-     *
      * <pre>
      *can add additional fields here without having to //extend StopTimeUpdate again
      * </pre>
+     *
+     * <code>optional string track = 1;</code>
+     * @return The track.
      */
     java.lang.String getTrack();
     /**
-     * <code>optional string track = 1;</code>
-     *
      * <pre>
      *can add additional fields here without having to //extend StopTimeUpdate again
      * </pre>
+     *
+     * <code>optional string track = 1;</code>
+     * @return The bytes for track.
      */
     com.google.protobuf.ByteString
         getTrackBytes();
 
     /**
      * <code>optional string trainStatus = 2;</code>
+     * @return Whether the trainStatus field is set.
      */
     boolean hasTrainStatus();
     /**
      * <code>optional string trainStatus = 2;</code>
+     * @return The trainStatus.
      */
     java.lang.String getTrainStatus();
     /**
      * <code>optional string trainStatus = 2;</code>
+     * @return The bytes for trainStatus.
      */
     com.google.protobuf.ByteString
         getTrainStatusBytes();
@@ -88,37 +100,40 @@ public final class GtfsRealtimeMNR {
   /**
    * Protobuf type {@code transit_realtime.MnrStopTimeUpdate}
    */
-  public static final class MnrStopTimeUpdate extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class MnrStopTimeUpdate extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.MnrStopTimeUpdate)
       MnrStopTimeUpdateOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use MnrStopTimeUpdate.newBuilder() to construct.
-    private MnrStopTimeUpdate(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private MnrStopTimeUpdate(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private MnrStopTimeUpdate(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final MnrStopTimeUpdate defaultInstance;
-    public static MnrStopTimeUpdate getDefaultInstance() {
-      return defaultInstance;
+    private MnrStopTimeUpdate() {
+      track_ = "";
+      trainStatus_ = "";
     }
 
-    public MnrStopTimeUpdate getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new MnrStopTimeUpdate();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private MnrStopTimeUpdate(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -130,13 +145,6 @@ public final class GtfsRealtimeMNR {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -149,13 +157,20 @@ public final class GtfsRealtimeMNR {
               trainStatus_ = bs;
               break;
             }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -166,47 +181,35 @@ public final class GtfsRealtimeMNR {
       return com.google.transit.realtime.GtfsRealtimeMNR.internal_static_transit_realtime_MnrStopTimeUpdate_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeMNR.internal_static_transit_realtime_MnrStopTimeUpdate_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate.class, com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<MnrStopTimeUpdate> PARSER =
-        new com.google.protobuf.AbstractParser<MnrStopTimeUpdate>() {
-      public MnrStopTimeUpdate parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MnrStopTimeUpdate(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<MnrStopTimeUpdate> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int TRACK_FIELD_NUMBER = 1;
-    private java.lang.Object track_;
+    private volatile java.lang.Object track_;
     /**
-     * <code>optional string track = 1;</code>
-     *
      * <pre>
      *can add additional fields here without having to //extend StopTimeUpdate again
      * </pre>
+     *
+     * <code>optional string track = 1;</code>
+     * @return Whether the track field is set.
      */
     public boolean hasTrack() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>optional string track = 1;</code>
-     *
      * <pre>
      *can add additional fields here without having to //extend StopTimeUpdate again
      * </pre>
+     *
+     * <code>optional string track = 1;</code>
+     * @return The track.
      */
     public java.lang.String getTrack() {
       java.lang.Object ref = track_;
@@ -223,11 +226,12 @@ public final class GtfsRealtimeMNR {
       }
     }
     /**
-     * <code>optional string track = 1;</code>
-     *
      * <pre>
      *can add additional fields here without having to //extend StopTimeUpdate again
      * </pre>
+     *
+     * <code>optional string track = 1;</code>
+     * @return The bytes for track.
      */
     public com.google.protobuf.ByteString
         getTrackBytes() {
@@ -244,15 +248,17 @@ public final class GtfsRealtimeMNR {
     }
 
     public static final int TRAINSTATUS_FIELD_NUMBER = 2;
-    private java.lang.Object trainStatus_;
+    private volatile java.lang.Object trainStatus_;
     /**
      * <code>optional string trainStatus = 2;</code>
+     * @return Whether the trainStatus field is set.
      */
     public boolean hasTrainStatus() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional string trainStatus = 2;</code>
+     * @return The trainStatus.
      */
     public java.lang.String getTrainStatus() {
       java.lang.Object ref = trainStatus_;
@@ -270,6 +276,7 @@ public final class GtfsRealtimeMNR {
     }
     /**
      * <code>optional string trainStatus = 2;</code>
+     * @return The bytes for trainStatus.
      */
     public com.google.protobuf.ByteString
         getTrainStatusBytes() {
@@ -285,11 +292,8 @@ public final class GtfsRealtimeMNR {
       }
     }
 
-    private void initFields() {
-      track_ = "";
-      trainStatus_ = "";
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -299,44 +303,90 @@ public final class GtfsRealtimeMNR {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getTrackBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, track_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(2, getTrainStatusBytes());
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, trainStatus_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getTrackBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, track_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(2, getTrainStatusBytes());
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, trainStatus_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate other = (com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate) obj;
+
+      if (hasTrack() != other.hasTrack()) return false;
+      if (hasTrack()) {
+        if (!getTrack()
+            .equals(other.getTrack())) return false;
+      }
+      if (hasTrainStatus() != other.hasTrainStatus()) return false;
+      if (hasTrainStatus()) {
+        if (!getTrainStatus()
+            .equals(other.getTrainStatus())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasTrack()) {
+        hash = (37 * hash) + TRACK_FIELD_NUMBER;
+        hash = (53 * hash) + getTrack().hashCode();
+      }
+      if (hasTrainStatus()) {
+        hash = (37 * hash) + TRAINSTATUS_FIELD_NUMBER;
+        hash = (53 * hash) + getTrainStatus().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -360,46 +410,59 @@ public final class GtfsRealtimeMNR {
     }
     public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -407,7 +470,7 @@ public final class GtfsRealtimeMNR {
      * Protobuf type {@code transit_realtime.MnrStopTimeUpdate}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.MnrStopTimeUpdate)
         com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdateOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -415,7 +478,8 @@ public final class GtfsRealtimeMNR {
         return com.google.transit.realtime.GtfsRealtimeMNR.internal_static_transit_realtime_MnrStopTimeUpdate_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeMNR.internal_static_transit_realtime_MnrStopTimeUpdate_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -428,18 +492,16 @@ public final class GtfsRealtimeMNR {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         track_ = "";
@@ -449,19 +511,18 @@ public final class GtfsRealtimeMNR {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeMNR.internal_static_transit_realtime_MnrStopTimeUpdate_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate build() {
         com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate result = buildPartial();
         if (!result.isInitialized()) {
@@ -470,15 +531,16 @@ public final class GtfsRealtimeMNR {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate buildPartial() {
         com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate result = new com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.track_ = track_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.trainStatus_ = trainStatus_;
@@ -487,6 +549,39 @@ public final class GtfsRealtimeMNR {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate)other);
@@ -508,14 +603,17 @@ public final class GtfsRealtimeMNR {
           trainStatus_ = other.trainStatus_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -525,7 +623,7 @@ public final class GtfsRealtimeMNR {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -537,21 +635,23 @@ public final class GtfsRealtimeMNR {
 
       private java.lang.Object track_ = "";
       /**
-       * <code>optional string track = 1;</code>
-       *
        * <pre>
        *can add additional fields here without having to //extend StopTimeUpdate again
        * </pre>
+       *
+       * <code>optional string track = 1;</code>
+       * @return Whether the track field is set.
        */
       public boolean hasTrack() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>optional string track = 1;</code>
-       *
        * <pre>
        *can add additional fields here without having to //extend StopTimeUpdate again
        * </pre>
+       *
+       * <code>optional string track = 1;</code>
+       * @return The track.
        */
       public java.lang.String getTrack() {
         java.lang.Object ref = track_;
@@ -568,11 +668,12 @@ public final class GtfsRealtimeMNR {
         }
       }
       /**
-       * <code>optional string track = 1;</code>
-       *
        * <pre>
        *can add additional fields here without having to //extend StopTimeUpdate again
        * </pre>
+       *
+       * <code>optional string track = 1;</code>
+       * @return The bytes for track.
        */
       public com.google.protobuf.ByteString
           getTrackBytes() {
@@ -588,11 +689,13 @@ public final class GtfsRealtimeMNR {
         }
       }
       /**
-       * <code>optional string track = 1;</code>
-       *
        * <pre>
        *can add additional fields here without having to //extend StopTimeUpdate again
        * </pre>
+       *
+       * <code>optional string track = 1;</code>
+       * @param value The track to set.
+       * @return This builder for chaining.
        */
       public Builder setTrack(
           java.lang.String value) {
@@ -605,11 +708,12 @@ public final class GtfsRealtimeMNR {
         return this;
       }
       /**
-       * <code>optional string track = 1;</code>
-       *
        * <pre>
        *can add additional fields here without having to //extend StopTimeUpdate again
        * </pre>
+       *
+       * <code>optional string track = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearTrack() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -618,11 +722,13 @@ public final class GtfsRealtimeMNR {
         return this;
       }
       /**
-       * <code>optional string track = 1;</code>
-       *
        * <pre>
        *can add additional fields here without having to //extend StopTimeUpdate again
        * </pre>
+       *
+       * <code>optional string track = 1;</code>
+       * @param value The bytes for track to set.
+       * @return This builder for chaining.
        */
       public Builder setTrackBytes(
           com.google.protobuf.ByteString value) {
@@ -638,12 +744,14 @@ public final class GtfsRealtimeMNR {
       private java.lang.Object trainStatus_ = "";
       /**
        * <code>optional string trainStatus = 2;</code>
+       * @return Whether the trainStatus field is set.
        */
       public boolean hasTrainStatus() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional string trainStatus = 2;</code>
+       * @return The trainStatus.
        */
       public java.lang.String getTrainStatus() {
         java.lang.Object ref = trainStatus_;
@@ -661,6 +769,7 @@ public final class GtfsRealtimeMNR {
       }
       /**
        * <code>optional string trainStatus = 2;</code>
+       * @return The bytes for trainStatus.
        */
       public com.google.protobuf.ByteString
           getTrainStatusBytes() {
@@ -677,6 +786,8 @@ public final class GtfsRealtimeMNR {
       }
       /**
        * <code>optional string trainStatus = 2;</code>
+       * @param value The trainStatus to set.
+       * @return This builder for chaining.
        */
       public Builder setTrainStatus(
           java.lang.String value) {
@@ -690,6 +801,7 @@ public final class GtfsRealtimeMNR {
       }
       /**
        * <code>optional string trainStatus = 2;</code>
+       * @return This builder for chaining.
        */
       public Builder clearTrainStatus() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -699,6 +811,8 @@ public final class GtfsRealtimeMNR {
       }
       /**
        * <code>optional string trainStatus = 2;</code>
+       * @param value The bytes for trainStatus to set.
+       * @return This builder for chaining.
        */
       public Builder setTrainStatusBytes(
           com.google.protobuf.ByteString value) {
@@ -710,16 +824,57 @@ public final class GtfsRealtimeMNR {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.MnrStopTimeUpdate)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.MnrStopTimeUpdate)
+    private static final com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate DEFAULT_INSTANCE;
     static {
-      defaultInstance = new MnrStopTimeUpdate(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.MnrStopTimeUpdate)
+    public static com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<MnrStopTimeUpdate>
+        PARSER = new com.google.protobuf.AbstractParser<MnrStopTimeUpdate>() {
+      @java.lang.Override
+      public MnrStopTimeUpdate parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MnrStopTimeUpdate(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MnrStopTimeUpdate> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MnrStopTimeUpdate> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public static final int MNR_STOP_TIME_UPDATE_FIELD_NUMBER = 1005;
@@ -735,15 +890,15 @@ public final class GtfsRealtimeMNR {
         com.google.transit.realtime.GtfsRealtimeMNR.MnrStopTimeUpdate.getDefaultInstance());
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_MnrStopTimeUpdate_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_MnrStopTimeUpdate_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
   }
-  private static com.google.protobuf.Descriptors.FileDescriptor
+  private static  com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
     java.lang.String[] descriptorData = {
@@ -757,23 +912,15 @@ public final class GtfsRealtimeMNR {
       "TimeUpdateB\035\n\033com.google.transit.realtim" +
       "e"
     };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
+    descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.transit.realtime.GtfsRealtime.getDescriptor(),
-        }, assigner);
+        });
     internal_static_transit_realtime_MnrStopTimeUpdate_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_transit_realtime_MnrStopTimeUpdate_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_MnrStopTimeUpdate_descriptor,
         new java.lang.String[] { "Track", "TrainStatus", });
     mnrStopTimeUpdate.internalInit(descriptor.getExtensions().get(0));

--- a/src/main/java/com/google/transit/realtime/GtfsRealtimeNYCT.java
+++ b/src/main/java/com/google/transit/realtime/GtfsRealtimeNYCT.java
@@ -38,103 +38,116 @@ package com.google.transit.realtime;
 public final class GtfsRealtimeNYCT {
   private GtfsRealtimeNYCT() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
     registry.add(com.google.transit.realtime.GtfsRealtimeNYCT.nyctFeedHeader);
     registry.add(com.google.transit.realtime.GtfsRealtimeNYCT.nyctTripDescriptor);
     registry.add(com.google.transit.realtime.GtfsRealtimeNYCT.nyctStopTimeUpdate);
+  }
+
+  public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   public interface TripReplacementPeriodOrBuilder extends
       // @@protoc_insertion_point(interface_extends:transit_realtime.TripReplacementPeriod)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional string route_id = 1;</code>
-     *
      * <pre>
      * The replacement period is for this route
      * </pre>
+     *
+     * <code>optional string route_id = 1;</code>
+     * @return Whether the routeId field is set.
      */
     boolean hasRouteId();
     /**
-     * <code>optional string route_id = 1;</code>
-     *
      * <pre>
      * The replacement period is for this route
      * </pre>
+     *
+     * <code>optional string route_id = 1;</code>
+     * @return The routeId.
      */
     java.lang.String getRouteId();
     /**
-     * <code>optional string route_id = 1;</code>
-     *
      * <pre>
      * The replacement period is for this route
      * </pre>
+     *
+     * <code>optional string route_id = 1;</code>
+     * @return The bytes for routeId.
      */
     com.google.protobuf.ByteString
         getRouteIdBytes();
 
     /**
-     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-     *
      * <pre>
      * The start time is omitted, the end time is currently now + 30 minutes for
      * all routes of the A division
      * </pre>
+     *
+     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
+     * @return Whether the replacementPeriod field is set.
      */
     boolean hasReplacementPeriod();
     /**
-     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-     *
      * <pre>
      * The start time is omitted, the end time is currently now + 30 minutes for
      * all routes of the A division
      * </pre>
+     *
+     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
+     * @return The replacementPeriod.
      */
     com.google.transit.realtime.GtfsRealtime.TimeRange getReplacementPeriod();
     /**
-     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-     *
      * <pre>
      * The start time is omitted, the end time is currently now + 30 minutes for
      * all routes of the A division
      * </pre>
+     *
+     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
      */
     com.google.transit.realtime.GtfsRealtime.TimeRangeOrBuilder getReplacementPeriodOrBuilder();
   }
   /**
    * Protobuf type {@code transit_realtime.TripReplacementPeriod}
    */
-  public static final class TripReplacementPeriod extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class TripReplacementPeriod extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.TripReplacementPeriod)
       TripReplacementPeriodOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use TripReplacementPeriod.newBuilder() to construct.
-    private TripReplacementPeriod(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private TripReplacementPeriod(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private TripReplacementPeriod(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final TripReplacementPeriod defaultInstance;
-    public static TripReplacementPeriod getDefaultInstance() {
-      return defaultInstance;
+    private TripReplacementPeriod() {
+      routeId_ = "";
     }
 
-    public TripReplacementPeriod getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new TripReplacementPeriod();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private TripReplacementPeriod(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -146,13 +159,6 @@ public final class GtfsRealtimeNYCT {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -161,7 +167,7 @@ public final class GtfsRealtimeNYCT {
             }
             case 18: {
               com.google.transit.realtime.GtfsRealtime.TimeRange.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = replacementPeriod_.toBuilder();
               }
               replacementPeriod_ = input.readMessage(com.google.transit.realtime.GtfsRealtime.TimeRange.PARSER, extensionRegistry);
@@ -172,13 +178,20 @@ public final class GtfsRealtimeNYCT {
               bitField0_ |= 0x00000002;
               break;
             }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -189,47 +202,35 @@ public final class GtfsRealtimeNYCT {
       return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_TripReplacementPeriod_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_TripReplacementPeriod_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.class, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<TripReplacementPeriod> PARSER =
-        new com.google.protobuf.AbstractParser<TripReplacementPeriod>() {
-      public TripReplacementPeriod parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new TripReplacementPeriod(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<TripReplacementPeriod> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int ROUTE_ID_FIELD_NUMBER = 1;
-    private java.lang.Object routeId_;
+    private volatile java.lang.Object routeId_;
     /**
-     * <code>optional string route_id = 1;</code>
-     *
      * <pre>
      * The replacement period is for this route
      * </pre>
+     *
+     * <code>optional string route_id = 1;</code>
+     * @return Whether the routeId field is set.
      */
     public boolean hasRouteId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>optional string route_id = 1;</code>
-     *
      * <pre>
      * The replacement period is for this route
      * </pre>
+     *
+     * <code>optional string route_id = 1;</code>
+     * @return The routeId.
      */
     public java.lang.String getRouteId() {
       java.lang.Object ref = routeId_;
@@ -246,11 +247,12 @@ public final class GtfsRealtimeNYCT {
       }
     }
     /**
-     * <code>optional string route_id = 1;</code>
-     *
      * <pre>
      * The replacement period is for this route
      * </pre>
+     *
+     * <code>optional string route_id = 1;</code>
+     * @return The bytes for routeId.
      */
     public com.google.protobuf.ByteString
         getRouteIdBytes() {
@@ -269,44 +271,43 @@ public final class GtfsRealtimeNYCT {
     public static final int REPLACEMENT_PERIOD_FIELD_NUMBER = 2;
     private com.google.transit.realtime.GtfsRealtime.TimeRange replacementPeriod_;
     /**
-     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-     *
      * <pre>
      * The start time is omitted, the end time is currently now + 30 minutes for
      * all routes of the A division
      * </pre>
+     *
+     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
+     * @return Whether the replacementPeriod field is set.
      */
     public boolean hasReplacementPeriod() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-     *
      * <pre>
      * The start time is omitted, the end time is currently now + 30 minutes for
      * all routes of the A division
      * </pre>
+     *
+     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
+     * @return The replacementPeriod.
      */
     public com.google.transit.realtime.GtfsRealtime.TimeRange getReplacementPeriod() {
-      return replacementPeriod_;
+      return replacementPeriod_ == null ? com.google.transit.realtime.GtfsRealtime.TimeRange.getDefaultInstance() : replacementPeriod_;
     }
     /**
-     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-     *
      * <pre>
      * The start time is omitted, the end time is currently now + 30 minutes for
      * all routes of the A division
      * </pre>
+     *
+     * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
      */
     public com.google.transit.realtime.GtfsRealtime.TimeRangeOrBuilder getReplacementPeriodOrBuilder() {
-      return replacementPeriod_;
+      return replacementPeriod_ == null ? com.google.transit.realtime.GtfsRealtime.TimeRange.getDefaultInstance() : replacementPeriod_;
     }
 
-    private void initFields() {
-      routeId_ = "";
-      replacementPeriod_ = com.google.transit.realtime.GtfsRealtime.TimeRange.getDefaultInstance();
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -322,44 +323,91 @@ public final class GtfsRealtimeNYCT {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getRouteIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, routeId_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeMessage(2, replacementPeriod_);
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeMessage(2, getReplacementPeriod());
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getRouteIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, routeId_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, replacementPeriod_);
+          .computeMessageSize(2, getReplacementPeriod());
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod other = (com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod) obj;
+
+      if (hasRouteId() != other.hasRouteId()) return false;
+      if (hasRouteId()) {
+        if (!getRouteId()
+            .equals(other.getRouteId())) return false;
+      }
+      if (hasReplacementPeriod() != other.hasReplacementPeriod()) return false;
+      if (hasReplacementPeriod()) {
+        if (!getReplacementPeriod()
+            .equals(other.getReplacementPeriod())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasRouteId()) {
+        hash = (37 * hash) + ROUTE_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRouteId().hashCode();
+      }
+      if (hasReplacementPeriod()) {
+        hash = (37 * hash) + REPLACEMENT_PERIOD_FIELD_NUMBER;
+        hash = (53 * hash) + getReplacementPeriod().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -383,46 +431,59 @@ public final class GtfsRealtimeNYCT {
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -430,7 +491,7 @@ public final class GtfsRealtimeNYCT {
      * Protobuf type {@code transit_realtime.TripReplacementPeriod}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.TripReplacementPeriod)
         com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -438,7 +499,8 @@ public final class GtfsRealtimeNYCT {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_TripReplacementPeriod_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_TripReplacementPeriod_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -451,25 +513,23 @@ public final class GtfsRealtimeNYCT {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getReplacementPeriodFieldBuilder();
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         routeId_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
         if (replacementPeriodBuilder_ == null) {
-          replacementPeriod_ = com.google.transit.realtime.GtfsRealtime.TimeRange.getDefaultInstance();
+          replacementPeriod_ = null;
         } else {
           replacementPeriodBuilder_.clear();
         }
@@ -477,19 +537,18 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_TripReplacementPeriod_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod build() {
         com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod result = buildPartial();
         if (!result.isInitialized()) {
@@ -498,27 +557,61 @@ public final class GtfsRealtimeNYCT {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod buildPartial() {
         com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod result = new com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.routeId_ = routeId_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (replacementPeriodBuilder_ == null) {
+            result.replacementPeriod_ = replacementPeriod_;
+          } else {
+            result.replacementPeriod_ = replacementPeriodBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
-        }
-        if (replacementPeriodBuilder_ == null) {
-          result.replacementPeriod_ = replacementPeriod_;
-        } else {
-          result.replacementPeriod_ = replacementPeriodBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod)other);
@@ -538,20 +631,22 @@ public final class GtfsRealtimeNYCT {
         if (other.hasReplacementPeriod()) {
           mergeReplacementPeriod(other.getReplacementPeriod());
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (hasReplacementPeriod()) {
           if (!getReplacementPeriod().isInitialized()) {
-            
             return false;
           }
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -561,7 +656,7 @@ public final class GtfsRealtimeNYCT {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -573,21 +668,23 @@ public final class GtfsRealtimeNYCT {
 
       private java.lang.Object routeId_ = "";
       /**
-       * <code>optional string route_id = 1;</code>
-       *
        * <pre>
        * The replacement period is for this route
        * </pre>
+       *
+       * <code>optional string route_id = 1;</code>
+       * @return Whether the routeId field is set.
        */
       public boolean hasRouteId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>optional string route_id = 1;</code>
-       *
        * <pre>
        * The replacement period is for this route
        * </pre>
+       *
+       * <code>optional string route_id = 1;</code>
+       * @return The routeId.
        */
       public java.lang.String getRouteId() {
         java.lang.Object ref = routeId_;
@@ -604,11 +701,12 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>optional string route_id = 1;</code>
-       *
        * <pre>
        * The replacement period is for this route
        * </pre>
+       *
+       * <code>optional string route_id = 1;</code>
+       * @return The bytes for routeId.
        */
       public com.google.protobuf.ByteString
           getRouteIdBytes() {
@@ -624,11 +722,13 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>optional string route_id = 1;</code>
-       *
        * <pre>
        * The replacement period is for this route
        * </pre>
+       *
+       * <code>optional string route_id = 1;</code>
+       * @param value The routeId to set.
+       * @return This builder for chaining.
        */
       public Builder setRouteId(
           java.lang.String value) {
@@ -641,11 +741,12 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional string route_id = 1;</code>
-       *
        * <pre>
        * The replacement period is for this route
        * </pre>
+       *
+       * <code>optional string route_id = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearRouteId() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -654,11 +755,13 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional string route_id = 1;</code>
-       *
        * <pre>
        * The replacement period is for this route
        * </pre>
+       *
+       * <code>optional string route_id = 1;</code>
+       * @param value The bytes for routeId to set.
+       * @return This builder for chaining.
        */
       public Builder setRouteIdBytes(
           com.google.protobuf.ByteString value) {
@@ -671,42 +774,44 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
 
-      private com.google.transit.realtime.GtfsRealtime.TimeRange replacementPeriod_ = com.google.transit.realtime.GtfsRealtime.TimeRange.getDefaultInstance();
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.transit.realtime.GtfsRealtime.TimeRange replacementPeriod_;
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.transit.realtime.GtfsRealtime.TimeRange, com.google.transit.realtime.GtfsRealtime.TimeRange.Builder, com.google.transit.realtime.GtfsRealtime.TimeRangeOrBuilder> replacementPeriodBuilder_;
       /**
-       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-       *
        * <pre>
        * The start time is omitted, the end time is currently now + 30 minutes for
        * all routes of the A division
        * </pre>
+       *
+       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
+       * @return Whether the replacementPeriod field is set.
        */
       public boolean hasReplacementPeriod() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
-       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-       *
        * <pre>
        * The start time is omitted, the end time is currently now + 30 minutes for
        * all routes of the A division
        * </pre>
+       *
+       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
+       * @return The replacementPeriod.
        */
       public com.google.transit.realtime.GtfsRealtime.TimeRange getReplacementPeriod() {
         if (replacementPeriodBuilder_ == null) {
-          return replacementPeriod_;
+          return replacementPeriod_ == null ? com.google.transit.realtime.GtfsRealtime.TimeRange.getDefaultInstance() : replacementPeriod_;
         } else {
           return replacementPeriodBuilder_.getMessage();
         }
       }
       /**
-       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-       *
        * <pre>
        * The start time is omitted, the end time is currently now + 30 minutes for
        * all routes of the A division
        * </pre>
+       *
+       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
        */
       public Builder setReplacementPeriod(com.google.transit.realtime.GtfsRealtime.TimeRange value) {
         if (replacementPeriodBuilder_ == null) {
@@ -722,12 +827,12 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-       *
        * <pre>
        * The start time is omitted, the end time is currently now + 30 minutes for
        * all routes of the A division
        * </pre>
+       *
+       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
        */
       public Builder setReplacementPeriod(
           com.google.transit.realtime.GtfsRealtime.TimeRange.Builder builderForValue) {
@@ -741,16 +846,17 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-       *
        * <pre>
        * The start time is omitted, the end time is currently now + 30 minutes for
        * all routes of the A division
        * </pre>
+       *
+       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
        */
       public Builder mergeReplacementPeriod(com.google.transit.realtime.GtfsRealtime.TimeRange value) {
         if (replacementPeriodBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
+              replacementPeriod_ != null &&
               replacementPeriod_ != com.google.transit.realtime.GtfsRealtime.TimeRange.getDefaultInstance()) {
             replacementPeriod_ =
               com.google.transit.realtime.GtfsRealtime.TimeRange.newBuilder(replacementPeriod_).mergeFrom(value).buildPartial();
@@ -765,16 +871,16 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-       *
        * <pre>
        * The start time is omitted, the end time is currently now + 30 minutes for
        * all routes of the A division
        * </pre>
+       *
+       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
        */
       public Builder clearReplacementPeriod() {
         if (replacementPeriodBuilder_ == null) {
-          replacementPeriod_ = com.google.transit.realtime.GtfsRealtime.TimeRange.getDefaultInstance();
+          replacementPeriod_ = null;
           onChanged();
         } else {
           replacementPeriodBuilder_.clear();
@@ -783,12 +889,12 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-       *
        * <pre>
        * The start time is omitted, the end time is currently now + 30 minutes for
        * all routes of the A division
        * </pre>
+       *
+       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
        */
       public com.google.transit.realtime.GtfsRealtime.TimeRange.Builder getReplacementPeriodBuilder() {
         bitField0_ |= 0x00000002;
@@ -796,33 +902,34 @@ public final class GtfsRealtimeNYCT {
         return getReplacementPeriodFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-       *
        * <pre>
        * The start time is omitted, the end time is currently now + 30 minutes for
        * all routes of the A division
        * </pre>
+       *
+       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
        */
       public com.google.transit.realtime.GtfsRealtime.TimeRangeOrBuilder getReplacementPeriodOrBuilder() {
         if (replacementPeriodBuilder_ != null) {
           return replacementPeriodBuilder_.getMessageOrBuilder();
         } else {
-          return replacementPeriod_;
+          return replacementPeriod_ == null ?
+              com.google.transit.realtime.GtfsRealtime.TimeRange.getDefaultInstance() : replacementPeriod_;
         }
       }
       /**
-       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
-       *
        * <pre>
        * The start time is omitted, the end time is currently now + 30 minutes for
        * all routes of the A division
        * </pre>
+       *
+       * <code>optional .transit_realtime.TimeRange replacement_period = 2;</code>
        */
-      private com.google.protobuf.SingleFieldBuilder<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.google.transit.realtime.GtfsRealtime.TimeRange, com.google.transit.realtime.GtfsRealtime.TimeRange.Builder, com.google.transit.realtime.GtfsRealtime.TimeRangeOrBuilder> 
           getReplacementPeriodFieldBuilder() {
         if (replacementPeriodBuilder_ == null) {
-          replacementPeriodBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          replacementPeriodBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.google.transit.realtime.GtfsRealtime.TimeRange, com.google.transit.realtime.GtfsRealtime.TimeRange.Builder, com.google.transit.realtime.GtfsRealtime.TimeRangeOrBuilder>(
                   getReplacementPeriod(),
                   getParentForChildren(),
@@ -831,16 +938,57 @@ public final class GtfsRealtimeNYCT {
         }
         return replacementPeriodBuilder_;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.TripReplacementPeriod)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.TripReplacementPeriod)
+    private static final com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod DEFAULT_INSTANCE;
     static {
-      defaultInstance = new TripReplacementPeriod(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.TripReplacementPeriod)
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<TripReplacementPeriod>
+        PARSER = new com.google.protobuf.AbstractParser<TripReplacementPeriod>() {
+      @java.lang.Override
+      public TripReplacementPeriod parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new TripReplacementPeriod(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<TripReplacementPeriod> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<TripReplacementPeriod> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface NyctFeedHeaderOrBuilder extends
@@ -848,37 +996,38 @@ public final class GtfsRealtimeNYCT {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>required string nyct_subway_version = 1;</code>
-     *
      * <pre>
      * Version of the NYCT Subway extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string nyct_subway_version = 1;</code>
+     * @return Whether the nyctSubwayVersion field is set.
      */
     boolean hasNyctSubwayVersion();
     /**
-     * <code>required string nyct_subway_version = 1;</code>
-     *
      * <pre>
      * Version of the NYCT Subway extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string nyct_subway_version = 1;</code>
+     * @return The nyctSubwayVersion.
      */
     java.lang.String getNyctSubwayVersion();
     /**
-     * <code>required string nyct_subway_version = 1;</code>
-     *
      * <pre>
      * Version of the NYCT Subway extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string nyct_subway_version = 1;</code>
+     * @return The bytes for nyctSubwayVersion.
      */
     com.google.protobuf.ByteString
         getNyctSubwayVersionBytes();
 
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -889,12 +1038,12 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     java.util.List<com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod> 
         getTripReplacementPeriodList();
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -905,11 +1054,11 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod getTripReplacementPeriod(int index);
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -920,11 +1069,11 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     int getTripReplacementPeriodCount();
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -935,12 +1084,12 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     java.util.List<? extends com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder> 
         getTripReplacementPeriodOrBuilderList();
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -951,48 +1100,53 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder getTripReplacementPeriodOrBuilder(
         int index);
   }
   /**
-   * Protobuf type {@code transit_realtime.NyctFeedHeader}
-   *
    * <pre>
    * NYCT Subway extensions for the feed header
    * </pre>
+   *
+   * Protobuf type {@code transit_realtime.NyctFeedHeader}
    */
-  public static final class NyctFeedHeader extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class NyctFeedHeader extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.NyctFeedHeader)
       NyctFeedHeaderOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use NyctFeedHeader.newBuilder() to construct.
-    private NyctFeedHeader(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private NyctFeedHeader(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private NyctFeedHeader(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final NyctFeedHeader defaultInstance;
-    public static NyctFeedHeader getDefaultInstance() {
-      return defaultInstance;
+    private NyctFeedHeader() {
+      nyctSubwayVersion_ = "";
+      tripReplacementPeriod_ = java.util.Collections.emptyList();
     }
 
-    public NyctFeedHeader getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new NyctFeedHeader();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private NyctFeedHeader(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1004,13 +1158,6 @@ public final class GtfsRealtimeNYCT {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -1018,11 +1165,19 @@ public final class GtfsRealtimeNYCT {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 tripReplacementPeriod_ = new java.util.ArrayList<com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod>();
                 mutable_bitField0_ |= 0x00000002;
               }
-              tripReplacementPeriod_.add(input.readMessage(com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.PARSER, extensionRegistry));
+              tripReplacementPeriod_.add(
+                  input.readMessage(com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.PARSER, extensionRegistry));
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
               break;
             }
           }
@@ -1031,9 +1186,9 @@ public final class GtfsRealtimeNYCT {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           tripReplacementPeriod_ = java.util.Collections.unmodifiableList(tripReplacementPeriod_);
         }
         this.unknownFields = unknownFields.build();
@@ -1045,49 +1200,37 @@ public final class GtfsRealtimeNYCT {
       return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctFeedHeader_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctFeedHeader_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader.class, com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<NyctFeedHeader> PARSER =
-        new com.google.protobuf.AbstractParser<NyctFeedHeader>() {
-      public NyctFeedHeader parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new NyctFeedHeader(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<NyctFeedHeader> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int NYCT_SUBWAY_VERSION_FIELD_NUMBER = 1;
-    private java.lang.Object nyctSubwayVersion_;
+    private volatile java.lang.Object nyctSubwayVersion_;
     /**
-     * <code>required string nyct_subway_version = 1;</code>
-     *
      * <pre>
      * Version of the NYCT Subway extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string nyct_subway_version = 1;</code>
+     * @return Whether the nyctSubwayVersion field is set.
      */
     public boolean hasNyctSubwayVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>required string nyct_subway_version = 1;</code>
-     *
      * <pre>
      * Version of the NYCT Subway extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string nyct_subway_version = 1;</code>
+     * @return The nyctSubwayVersion.
      */
     public java.lang.String getNyctSubwayVersion() {
       java.lang.Object ref = nyctSubwayVersion_;
@@ -1104,12 +1247,13 @@ public final class GtfsRealtimeNYCT {
       }
     }
     /**
-     * <code>required string nyct_subway_version = 1;</code>
-     *
      * <pre>
      * Version of the NYCT Subway extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string nyct_subway_version = 1;</code>
+     * @return The bytes for nyctSubwayVersion.
      */
     public com.google.protobuf.ByteString
         getNyctSubwayVersionBytes() {
@@ -1128,8 +1272,6 @@ public final class GtfsRealtimeNYCT {
     public static final int TRIP_REPLACEMENT_PERIOD_FIELD_NUMBER = 2;
     private java.util.List<com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod> tripReplacementPeriod_;
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -1140,13 +1282,13 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     public java.util.List<com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod> getTripReplacementPeriodList() {
       return tripReplacementPeriod_;
     }
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -1157,14 +1299,14 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     public java.util.List<? extends com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder> 
         getTripReplacementPeriodOrBuilderList() {
       return tripReplacementPeriod_;
     }
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -1175,13 +1317,13 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     public int getTripReplacementPeriodCount() {
       return tripReplacementPeriod_.size();
     }
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -1192,13 +1334,13 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod getTripReplacementPeriod(int index) {
       return tripReplacementPeriod_.get(index);
     }
     /**
-     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-     *
      * <pre>
      * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
      * trip within the trip_replacement_period. 
@@ -1209,17 +1351,16 @@ public final class GtfsRealtimeNYCT {
      * a list of the routes where the trips in the feed replace all 
      * scheduled trips within the replacement period.
      * </pre>
+     *
+     * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
      */
     public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder getTripReplacementPeriodOrBuilder(
         int index) {
       return tripReplacementPeriod_.get(index);
     }
 
-    private void initFields() {
-      nyctSubwayVersion_ = "";
-      tripReplacementPeriod_ = java.util.Collections.emptyList();
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1239,44 +1380,88 @@ public final class GtfsRealtimeNYCT {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getNyctSubwayVersionBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, nyctSubwayVersion_);
       }
       for (int i = 0; i < tripReplacementPeriod_.size(); i++) {
         output.writeMessage(2, tripReplacementPeriod_.get(i));
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getNyctSubwayVersionBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, nyctSubwayVersion_);
       }
       for (int i = 0; i < tripReplacementPeriod_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, tripReplacementPeriod_.get(i));
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader other = (com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader) obj;
+
+      if (hasNyctSubwayVersion() != other.hasNyctSubwayVersion()) return false;
+      if (hasNyctSubwayVersion()) {
+        if (!getNyctSubwayVersion()
+            .equals(other.getNyctSubwayVersion())) return false;
+      }
+      if (!getTripReplacementPeriodList()
+          .equals(other.getTripReplacementPeriodList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasNyctSubwayVersion()) {
+        hash = (37 * hash) + NYCT_SUBWAY_VERSION_FIELD_NUMBER;
+        hash = (53 * hash) + getNyctSubwayVersion().hashCode();
+      }
+      if (getTripReplacementPeriodCount() > 0) {
+        hash = (37 * hash) + TRIP_REPLACEMENT_PERIOD_FIELD_NUMBER;
+        hash = (53 * hash) + getTripReplacementPeriodList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1300,58 +1485,71 @@ public final class GtfsRealtimeNYCT {
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /**
-     * Protobuf type {@code transit_realtime.NyctFeedHeader}
-     *
      * <pre>
      * NYCT Subway extensions for the feed header
      * </pre>
+     *
+     * Protobuf type {@code transit_realtime.NyctFeedHeader}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.NyctFeedHeader)
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeaderOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1359,7 +1557,8 @@ public final class GtfsRealtimeNYCT {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctFeedHeader_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctFeedHeader_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1372,19 +1571,17 @@ public final class GtfsRealtimeNYCT {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
           getTripReplacementPeriodFieldBuilder();
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         nyctSubwayVersion_ = "";
@@ -1398,19 +1595,18 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctFeedHeader_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader build() {
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader result = buildPartial();
         if (!result.isInitialized()) {
@@ -1419,16 +1615,17 @@ public final class GtfsRealtimeNYCT {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader buildPartial() {
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader result = new com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.nyctSubwayVersion_ = nyctSubwayVersion_;
         if (tripReplacementPeriodBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             tripReplacementPeriod_ = java.util.Collections.unmodifiableList(tripReplacementPeriod_);
             bitField0_ = (bitField0_ & ~0x00000002);
           }
@@ -1441,6 +1638,39 @@ public final class GtfsRealtimeNYCT {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader)other);
@@ -1476,31 +1706,32 @@ public final class GtfsRealtimeNYCT {
               tripReplacementPeriod_ = other.tripReplacementPeriod_;
               bitField0_ = (bitField0_ & ~0x00000002);
               tripReplacementPeriodBuilder_ = 
-                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getTripReplacementPeriodFieldBuilder() : null;
             } else {
               tripReplacementPeriodBuilder_.addAllMessages(other.tripReplacementPeriod_);
             }
           }
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasNyctSubwayVersion()) {
-          
           return false;
         }
         for (int i = 0; i < getTripReplacementPeriodCount(); i++) {
           if (!getTripReplacementPeriod(i).isInitialized()) {
-            
             return false;
           }
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1510,7 +1741,7 @@ public final class GtfsRealtimeNYCT {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1522,23 +1753,25 @@ public final class GtfsRealtimeNYCT {
 
       private java.lang.Object nyctSubwayVersion_ = "";
       /**
-       * <code>required string nyct_subway_version = 1;</code>
-       *
        * <pre>
        * Version of the NYCT Subway extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string nyct_subway_version = 1;</code>
+       * @return Whether the nyctSubwayVersion field is set.
        */
       public boolean hasNyctSubwayVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>required string nyct_subway_version = 1;</code>
-       *
        * <pre>
        * Version of the NYCT Subway extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string nyct_subway_version = 1;</code>
+       * @return The nyctSubwayVersion.
        */
       public java.lang.String getNyctSubwayVersion() {
         java.lang.Object ref = nyctSubwayVersion_;
@@ -1555,12 +1788,13 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>required string nyct_subway_version = 1;</code>
-       *
        * <pre>
        * Version of the NYCT Subway extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string nyct_subway_version = 1;</code>
+       * @return The bytes for nyctSubwayVersion.
        */
       public com.google.protobuf.ByteString
           getNyctSubwayVersionBytes() {
@@ -1576,12 +1810,14 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>required string nyct_subway_version = 1;</code>
-       *
        * <pre>
        * Version of the NYCT Subway extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string nyct_subway_version = 1;</code>
+       * @param value The nyctSubwayVersion to set.
+       * @return This builder for chaining.
        */
       public Builder setNyctSubwayVersion(
           java.lang.String value) {
@@ -1594,12 +1830,13 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>required string nyct_subway_version = 1;</code>
-       *
        * <pre>
        * Version of the NYCT Subway extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string nyct_subway_version = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearNyctSubwayVersion() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -1608,12 +1845,14 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>required string nyct_subway_version = 1;</code>
-       *
        * <pre>
        * Version of the NYCT Subway extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string nyct_subway_version = 1;</code>
+       * @param value The bytes for nyctSubwayVersion to set.
+       * @return This builder for chaining.
        */
       public Builder setNyctSubwayVersionBytes(
           com.google.protobuf.ByteString value) {
@@ -1629,18 +1868,16 @@ public final class GtfsRealtimeNYCT {
       private java.util.List<com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod> tripReplacementPeriod_ =
         java.util.Collections.emptyList();
       private void ensureTripReplacementPeriodIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000002) != 0)) {
           tripReplacementPeriod_ = new java.util.ArrayList<com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod>(tripReplacementPeriod_);
           bitField0_ |= 0x00000002;
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder> tripReplacementPeriodBuilder_;
 
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1651,6 +1888,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public java.util.List<com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod> getTripReplacementPeriodList() {
         if (tripReplacementPeriodBuilder_ == null) {
@@ -1660,8 +1899,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1672,6 +1909,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public int getTripReplacementPeriodCount() {
         if (tripReplacementPeriodBuilder_ == null) {
@@ -1681,8 +1920,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1693,6 +1930,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod getTripReplacementPeriod(int index) {
         if (tripReplacementPeriodBuilder_ == null) {
@@ -1702,8 +1941,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1714,6 +1951,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public Builder setTripReplacementPeriod(
           int index, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod value) {
@@ -1730,8 +1969,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1742,6 +1979,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public Builder setTripReplacementPeriod(
           int index, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder builderForValue) {
@@ -1755,8 +1994,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1767,6 +2004,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public Builder addTripReplacementPeriod(com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod value) {
         if (tripReplacementPeriodBuilder_ == null) {
@@ -1782,8 +2021,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1794,6 +2031,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public Builder addTripReplacementPeriod(
           int index, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod value) {
@@ -1810,8 +2049,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1822,6 +2059,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public Builder addTripReplacementPeriod(
           com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder builderForValue) {
@@ -1835,8 +2074,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1847,6 +2084,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public Builder addTripReplacementPeriod(
           int index, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder builderForValue) {
@@ -1860,8 +2099,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1872,6 +2109,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public Builder addAllTripReplacementPeriod(
           java.lang.Iterable<? extends com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod> values) {
@@ -1886,8 +2125,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1898,6 +2135,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public Builder clearTripReplacementPeriod() {
         if (tripReplacementPeriodBuilder_ == null) {
@@ -1910,8 +2149,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1922,6 +2159,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public Builder removeTripReplacementPeriod(int index) {
         if (tripReplacementPeriodBuilder_ == null) {
@@ -1934,8 +2173,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1946,14 +2183,14 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder getTripReplacementPeriodBuilder(
           int index) {
         return getTripReplacementPeriodFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1964,6 +2201,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder getTripReplacementPeriodOrBuilder(
           int index) {
@@ -1973,8 +2212,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -1985,6 +2222,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public java.util.List<? extends com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder> 
            getTripReplacementPeriodOrBuilderList() {
@@ -1995,8 +2234,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -2007,14 +2244,14 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder addTripReplacementPeriodBuilder() {
         return getTripReplacementPeriodFieldBuilder().addBuilder(
             com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.getDefaultInstance());
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -2025,6 +2262,8 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder addTripReplacementPeriodBuilder(
           int index) {
@@ -2032,8 +2271,6 @@ public final class GtfsRealtimeNYCT {
             index, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.getDefaultInstance());
       }
       /**
-       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
-       *
        * <pre>
        * For the NYCT Subway, the GTFS-realtime feed replaces any scheduled
        * trip within the trip_replacement_period. 
@@ -2044,35 +2281,78 @@ public final class GtfsRealtimeNYCT {
        * a list of the routes where the trips in the feed replace all 
        * scheduled trips within the replacement period.
        * </pre>
+       *
+       * <code>repeated .transit_realtime.TripReplacementPeriod trip_replacement_period = 2;</code>
        */
       public java.util.List<com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder> 
            getTripReplacementPeriodBuilderList() {
         return getTripReplacementPeriodFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilder<
+      private com.google.protobuf.RepeatedFieldBuilderV3<
           com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder> 
           getTripReplacementPeriodFieldBuilder() {
         if (tripReplacementPeriodBuilder_ == null) {
-          tripReplacementPeriodBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+          tripReplacementPeriodBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriod.Builder, com.google.transit.realtime.GtfsRealtimeNYCT.TripReplacementPeriodOrBuilder>(
                   tripReplacementPeriod_,
-                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
                   isClean());
           tripReplacementPeriod_ = null;
         }
         return tripReplacementPeriodBuilder_;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.NyctFeedHeader)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.NyctFeedHeader)
+    private static final com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader DEFAULT_INSTANCE;
     static {
-      defaultInstance = new NyctFeedHeader(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.NyctFeedHeader)
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<NyctFeedHeader>
+        PARSER = new com.google.protobuf.AbstractParser<NyctFeedHeader>() {
+      @java.lang.Override
+      public NyctFeedHeader parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new NyctFeedHeader(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<NyctFeedHeader> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<NyctFeedHeader> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeNYCT.NyctFeedHeader getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface NyctTripDescriptorOrBuilder extends
@@ -2080,8 +2360,6 @@ public final class GtfsRealtimeNYCT {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional string train_id = 1;</code>
-     *
      * <pre>
      * The nyct_train_id is meant for internal use only. It provides an
      * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -2105,11 +2383,12 @@ public final class GtfsRealtimeNYCT {
      * is followed by a three character "Origin Location" / "Destination
      * Location"
      * </pre>
+     *
+     * <code>optional string train_id = 1;</code>
+     * @return Whether the trainId field is set.
      */
     boolean hasTrainId();
     /**
-     * <code>optional string train_id = 1;</code>
-     *
      * <pre>
      * The nyct_train_id is meant for internal use only. It provides an
      * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -2133,11 +2412,12 @@ public final class GtfsRealtimeNYCT {
      * is followed by a three character "Origin Location" / "Destination
      * Location"
      * </pre>
+     *
+     * <code>optional string train_id = 1;</code>
+     * @return The trainId.
      */
     java.lang.String getTrainId();
     /**
-     * <code>optional string train_id = 1;</code>
-     *
      * <pre>
      * The nyct_train_id is meant for internal use only. It provides an
      * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -2161,13 +2441,14 @@ public final class GtfsRealtimeNYCT {
      * is followed by a three character "Origin Location" / "Destination
      * Location"
      * </pre>
+     *
+     * <code>optional string train_id = 1;</code>
+     * @return The bytes for trainId.
      */
     com.google.protobuf.ByteString
         getTrainIdBytes();
 
     /**
-     * <code>optional bool is_assigned = 2;</code>
-     *
      * <pre>
      * This trip has been assigned to a physical train. If true, this trip is
      * already underway or most likely will depart shortly. 
@@ -2181,11 +2462,12 @@ public final class GtfsRealtimeNYCT {
      * to a storage location or assigned a nyct_train_id when a determination for
      * service is made.
      * </pre>
+     *
+     * <code>optional bool is_assigned = 2;</code>
+     * @return Whether the isAssigned field is set.
      */
     boolean hasIsAssigned();
     /**
-     * <code>optional bool is_assigned = 2;</code>
-     *
      * <pre>
      * This trip has been assigned to a physical train. If true, this trip is
      * already underway or most likely will depart shortly. 
@@ -2199,12 +2481,13 @@ public final class GtfsRealtimeNYCT {
      * to a storage location or assigned a nyct_train_id when a determination for
      * service is made.
      * </pre>
+     *
+     * <code>optional bool is_assigned = 2;</code>
+     * @return The isAssigned.
      */
     boolean getIsAssigned();
 
     /**
-     * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
-     *
      * <pre>
      * Uptown and Bronx-bound trains are moving NORTH.
      * Times Square Shuttle to Grand Central is also northbound.
@@ -2213,11 +2496,12 @@ public final class GtfsRealtimeNYCT {
      * 
      * EAST and WEST are not used currently.
      * </pre>
+     *
+     * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
+     * @return Whether the direction field is set.
      */
     boolean hasDirection();
     /**
-     * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
-     *
      * <pre>
      * Uptown and Bronx-bound trains are moving NORTH.
      * Times Square Shuttle to Grand Central is also northbound.
@@ -2226,47 +2510,53 @@ public final class GtfsRealtimeNYCT {
      * 
      * EAST and WEST are not used currently.
      * </pre>
+     *
+     * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
+     * @return The direction.
      */
     com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction getDirection();
   }
   /**
-   * Protobuf type {@code transit_realtime.NyctTripDescriptor}
-   *
    * <pre>
    * NYCT Subway extensions for the trip descriptor
    * </pre>
+   *
+   * Protobuf type {@code transit_realtime.NyctTripDescriptor}
    */
-  public static final class NyctTripDescriptor extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class NyctTripDescriptor extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.NyctTripDescriptor)
       NyctTripDescriptorOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use NyctTripDescriptor.newBuilder() to construct.
-    private NyctTripDescriptor(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private NyctTripDescriptor(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private NyctTripDescriptor(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final NyctTripDescriptor defaultInstance;
-    public static NyctTripDescriptor getDefaultInstance() {
-      return defaultInstance;
+    private NyctTripDescriptor() {
+      trainId_ = "";
+      direction_ = 1;
     }
 
-    public NyctTripDescriptor getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new NyctTripDescriptor();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private NyctTripDescriptor(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2278,13 +2568,6 @@ public final class GtfsRealtimeNYCT {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -2298,12 +2581,20 @@ public final class GtfsRealtimeNYCT {
             }
             case 24: {
               int rawValue = input.readEnum();
+                @SuppressWarnings("deprecation")
               com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction value = com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction.valueOf(rawValue);
               if (value == null) {
                 unknownFields.mergeVarintField(3, rawValue);
               } else {
                 bitField0_ |= 0x00000004;
-                direction_ = value;
+                direction_ = rawValue;
+              }
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
               }
               break;
             }
@@ -2313,7 +2604,7 @@ public final class GtfsRealtimeNYCT {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -2324,53 +2615,39 @@ public final class GtfsRealtimeNYCT {
       return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctTripDescriptor_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctTripDescriptor_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.class, com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<NyctTripDescriptor> PARSER =
-        new com.google.protobuf.AbstractParser<NyctTripDescriptor>() {
-      public NyctTripDescriptor parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new NyctTripDescriptor(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<NyctTripDescriptor> getParserForType() {
-      return PARSER;
-    }
-
     /**
-     * Protobuf enum {@code transit_realtime.NyctTripDescriptor.Direction}
-     *
      * <pre>
      * The direction the train is moving. 
      * </pre>
+     *
+     * Protobuf enum {@code transit_realtime.NyctTripDescriptor.Direction}
      */
     public enum Direction
         implements com.google.protobuf.ProtocolMessageEnum {
       /**
        * <code>NORTH = 1;</code>
        */
-      NORTH(0, 1),
+      NORTH(1),
       /**
        * <code>EAST = 2;</code>
        */
-      EAST(1, 2),
+      EAST(2),
       /**
        * <code>SOUTH = 3;</code>
        */
-      SOUTH(2, 3),
+      SOUTH(3),
       /**
        * <code>WEST = 4;</code>
        */
-      WEST(3, 4),
+      WEST(4),
       ;
 
       /**
@@ -2391,9 +2668,25 @@ public final class GtfsRealtimeNYCT {
       public static final int WEST_VALUE = 4;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static Direction valueOf(int value) {
+        return forNumber(value);
+      }
+
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       */
+      public static Direction forNumber(int value) {
         switch (value) {
           case 1: return NORTH;
           case 2: return EAST;
@@ -2407,17 +2700,17 @@ public final class GtfsRealtimeNYCT {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<Direction>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          Direction> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<Direction>() {
               public Direction findValueByNumber(int number) {
-                return Direction.valueOf(number);
+                return Direction.forNumber(number);
               }
             };
 
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
+        return getDescriptor().getValues().get(ordinal());
       }
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
@@ -2439,11 +2732,9 @@ public final class GtfsRealtimeNYCT {
         return VALUES[desc.getIndex()];
       }
 
-      private final int index;
       private final int value;
 
-      private Direction(int index, int value) {
-        this.index = index;
+      private Direction(int value) {
         this.value = value;
       }
 
@@ -2452,10 +2743,8 @@ public final class GtfsRealtimeNYCT {
 
     private int bitField0_;
     public static final int TRAIN_ID_FIELD_NUMBER = 1;
-    private java.lang.Object trainId_;
+    private volatile java.lang.Object trainId_;
     /**
-     * <code>optional string train_id = 1;</code>
-     *
      * <pre>
      * The nyct_train_id is meant for internal use only. It provides an
      * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -2479,13 +2768,14 @@ public final class GtfsRealtimeNYCT {
      * is followed by a three character "Origin Location" / "Destination
      * Location"
      * </pre>
+     *
+     * <code>optional string train_id = 1;</code>
+     * @return Whether the trainId field is set.
      */
     public boolean hasTrainId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>optional string train_id = 1;</code>
-     *
      * <pre>
      * The nyct_train_id is meant for internal use only. It provides an
      * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -2509,6 +2799,9 @@ public final class GtfsRealtimeNYCT {
      * is followed by a three character "Origin Location" / "Destination
      * Location"
      * </pre>
+     *
+     * <code>optional string train_id = 1;</code>
+     * @return The trainId.
      */
     public java.lang.String getTrainId() {
       java.lang.Object ref = trainId_;
@@ -2525,8 +2818,6 @@ public final class GtfsRealtimeNYCT {
       }
     }
     /**
-     * <code>optional string train_id = 1;</code>
-     *
      * <pre>
      * The nyct_train_id is meant for internal use only. It provides an
      * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -2550,6 +2841,9 @@ public final class GtfsRealtimeNYCT {
      * is followed by a three character "Origin Location" / "Destination
      * Location"
      * </pre>
+     *
+     * <code>optional string train_id = 1;</code>
+     * @return The bytes for trainId.
      */
     public com.google.protobuf.ByteString
         getTrainIdBytes() {
@@ -2568,8 +2862,6 @@ public final class GtfsRealtimeNYCT {
     public static final int IS_ASSIGNED_FIELD_NUMBER = 2;
     private boolean isAssigned_;
     /**
-     * <code>optional bool is_assigned = 2;</code>
-     *
      * <pre>
      * This trip has been assigned to a physical train. If true, this trip is
      * already underway or most likely will depart shortly. 
@@ -2583,13 +2875,14 @@ public final class GtfsRealtimeNYCT {
      * to a storage location or assigned a nyct_train_id when a determination for
      * service is made.
      * </pre>
+     *
+     * <code>optional bool is_assigned = 2;</code>
+     * @return Whether the isAssigned field is set.
      */
     public boolean hasIsAssigned() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     * <code>optional bool is_assigned = 2;</code>
-     *
      * <pre>
      * This trip has been assigned to a physical train. If true, this trip is
      * already underway or most likely will depart shortly. 
@@ -2603,16 +2896,17 @@ public final class GtfsRealtimeNYCT {
      * to a storage location or assigned a nyct_train_id when a determination for
      * service is made.
      * </pre>
+     *
+     * <code>optional bool is_assigned = 2;</code>
+     * @return The isAssigned.
      */
     public boolean getIsAssigned() {
       return isAssigned_;
     }
 
     public static final int DIRECTION_FIELD_NUMBER = 3;
-    private com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction direction_;
+    private int direction_;
     /**
-     * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
-     *
      * <pre>
      * Uptown and Bronx-bound trains are moving NORTH.
      * Times Square Shuttle to Grand Central is also northbound.
@@ -2621,13 +2915,14 @@ public final class GtfsRealtimeNYCT {
      * 
      * EAST and WEST are not used currently.
      * </pre>
+     *
+     * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
+     * @return Whether the direction field is set.
      */
     public boolean hasDirection() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
-     * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
-     *
      * <pre>
      * Uptown and Bronx-bound trains are moving NORTH.
      * Times Square Shuttle to Grand Central is also northbound.
@@ -2636,17 +2931,18 @@ public final class GtfsRealtimeNYCT {
      * 
      * EAST and WEST are not used currently.
      * </pre>
+     *
+     * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
+     * @return The direction.
      */
     public com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction getDirection() {
-      return direction_;
+      @SuppressWarnings("deprecation")
+      com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction result = com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction.valueOf(direction_);
+      return result == null ? com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction.NORTH : result;
     }
 
-    private void initFields() {
-      trainId_ = "";
-      isAssigned_ = false;
-      direction_ = com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction.NORTH;
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2656,51 +2952,107 @@ public final class GtfsRealtimeNYCT {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getTrainIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, trainId_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBool(2, isAssigned_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeEnum(3, direction_.getNumber());
+      if (((bitField0_ & 0x00000004) != 0)) {
+        output.writeEnum(3, direction_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getTrainIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, trainId_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(2, isAssigned_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(3, direction_.getNumber());
+          .computeEnumSize(3, direction_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor other = (com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor) obj;
+
+      if (hasTrainId() != other.hasTrainId()) return false;
+      if (hasTrainId()) {
+        if (!getTrainId()
+            .equals(other.getTrainId())) return false;
+      }
+      if (hasIsAssigned() != other.hasIsAssigned()) return false;
+      if (hasIsAssigned()) {
+        if (getIsAssigned()
+            != other.getIsAssigned()) return false;
+      }
+      if (hasDirection() != other.hasDirection()) return false;
+      if (hasDirection()) {
+        if (direction_ != other.direction_) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasTrainId()) {
+        hash = (37 * hash) + TRAIN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getTrainId().hashCode();
+      }
+      if (hasIsAssigned()) {
+        hash = (37 * hash) + IS_ASSIGNED_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+            getIsAssigned());
+      }
+      if (hasDirection()) {
+        hash = (37 * hash) + DIRECTION_FIELD_NUMBER;
+        hash = (53 * hash) + direction_;
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2724,58 +3076,71 @@ public final class GtfsRealtimeNYCT {
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /**
-     * Protobuf type {@code transit_realtime.NyctTripDescriptor}
-     *
      * <pre>
      * NYCT Subway extensions for the trip descriptor
      * </pre>
+     *
+     * Protobuf type {@code transit_realtime.NyctTripDescriptor}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.NyctTripDescriptor)
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -2783,7 +3148,8 @@ public final class GtfsRealtimeNYCT {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctTripDescriptor_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctTripDescriptor_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2796,42 +3162,39 @@ public final class GtfsRealtimeNYCT {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         trainId_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
         isAssigned_ = false;
         bitField0_ = (bitField0_ & ~0x00000002);
-        direction_ = com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction.NORTH;
+        direction_ = 1;
         bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctTripDescriptor_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor build() {
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor result = buildPartial();
         if (!result.isInitialized()) {
@@ -2840,19 +3203,20 @@ public final class GtfsRealtimeNYCT {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor buildPartial() {
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor result = new com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.trainId_ = trainId_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.isAssigned_ = isAssigned_;
           to_bitField0_ |= 0x00000002;
         }
-        result.isAssigned_ = isAssigned_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.direction_ = direction_;
@@ -2861,6 +3225,39 @@ public final class GtfsRealtimeNYCT {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor)other);
@@ -2883,14 +3280,17 @@ public final class GtfsRealtimeNYCT {
         if (other.hasDirection()) {
           setDirection(other.getDirection());
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2900,7 +3300,7 @@ public final class GtfsRealtimeNYCT {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -2912,8 +3312,6 @@ public final class GtfsRealtimeNYCT {
 
       private java.lang.Object trainId_ = "";
       /**
-       * <code>optional string train_id = 1;</code>
-       *
        * <pre>
        * The nyct_train_id is meant for internal use only. It provides an
        * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -2937,13 +3335,14 @@ public final class GtfsRealtimeNYCT {
        * is followed by a three character "Origin Location" / "Destination
        * Location"
        * </pre>
+       *
+       * <code>optional string train_id = 1;</code>
+       * @return Whether the trainId field is set.
        */
       public boolean hasTrainId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>optional string train_id = 1;</code>
-       *
        * <pre>
        * The nyct_train_id is meant for internal use only. It provides an
        * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -2967,6 +3366,9 @@ public final class GtfsRealtimeNYCT {
        * is followed by a three character "Origin Location" / "Destination
        * Location"
        * </pre>
+       *
+       * <code>optional string train_id = 1;</code>
+       * @return The trainId.
        */
       public java.lang.String getTrainId() {
         java.lang.Object ref = trainId_;
@@ -2983,8 +3385,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>optional string train_id = 1;</code>
-       *
        * <pre>
        * The nyct_train_id is meant for internal use only. It provides an
        * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -3008,6 +3408,9 @@ public final class GtfsRealtimeNYCT {
        * is followed by a three character "Origin Location" / "Destination
        * Location"
        * </pre>
+       *
+       * <code>optional string train_id = 1;</code>
+       * @return The bytes for trainId.
        */
       public com.google.protobuf.ByteString
           getTrainIdBytes() {
@@ -3023,8 +3426,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>optional string train_id = 1;</code>
-       *
        * <pre>
        * The nyct_train_id is meant for internal use only. It provides an
        * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -3048,6 +3449,10 @@ public final class GtfsRealtimeNYCT {
        * is followed by a three character "Origin Location" / "Destination
        * Location"
        * </pre>
+       *
+       * <code>optional string train_id = 1;</code>
+       * @param value The trainId to set.
+       * @return This builder for chaining.
        */
       public Builder setTrainId(
           java.lang.String value) {
@@ -3060,8 +3465,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional string train_id = 1;</code>
-       *
        * <pre>
        * The nyct_train_id is meant for internal use only. It provides an
        * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -3085,6 +3488,9 @@ public final class GtfsRealtimeNYCT {
        * is followed by a three character "Origin Location" / "Destination
        * Location"
        * </pre>
+       *
+       * <code>optional string train_id = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearTrainId() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -3093,8 +3499,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional string train_id = 1;</code>
-       *
        * <pre>
        * The nyct_train_id is meant for internal use only. It provides an
        * easy way to associated GTFS-realtime trip identifiers with NYCT rail
@@ -3118,6 +3522,10 @@ public final class GtfsRealtimeNYCT {
        * is followed by a three character "Origin Location" / "Destination
        * Location"
        * </pre>
+       *
+       * <code>optional string train_id = 1;</code>
+       * @param value The bytes for trainId to set.
+       * @return This builder for chaining.
        */
       public Builder setTrainIdBytes(
           com.google.protobuf.ByteString value) {
@@ -3132,8 +3540,6 @@ public final class GtfsRealtimeNYCT {
 
       private boolean isAssigned_ ;
       /**
-       * <code>optional bool is_assigned = 2;</code>
-       *
        * <pre>
        * This trip has been assigned to a physical train. If true, this trip is
        * already underway or most likely will depart shortly. 
@@ -3147,13 +3553,14 @@ public final class GtfsRealtimeNYCT {
        * to a storage location or assigned a nyct_train_id when a determination for
        * service is made.
        * </pre>
+       *
+       * <code>optional bool is_assigned = 2;</code>
+       * @return Whether the isAssigned field is set.
        */
       public boolean hasIsAssigned() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
-       * <code>optional bool is_assigned = 2;</code>
-       *
        * <pre>
        * This trip has been assigned to a physical train. If true, this trip is
        * already underway or most likely will depart shortly. 
@@ -3167,13 +3574,14 @@ public final class GtfsRealtimeNYCT {
        * to a storage location or assigned a nyct_train_id when a determination for
        * service is made.
        * </pre>
+       *
+       * <code>optional bool is_assigned = 2;</code>
+       * @return The isAssigned.
        */
       public boolean getIsAssigned() {
         return isAssigned_;
       }
       /**
-       * <code>optional bool is_assigned = 2;</code>
-       *
        * <pre>
        * This trip has been assigned to a physical train. If true, this trip is
        * already underway or most likely will depart shortly. 
@@ -3187,6 +3595,10 @@ public final class GtfsRealtimeNYCT {
        * to a storage location or assigned a nyct_train_id when a determination for
        * service is made.
        * </pre>
+       *
+       * <code>optional bool is_assigned = 2;</code>
+       * @param value The isAssigned to set.
+       * @return This builder for chaining.
        */
       public Builder setIsAssigned(boolean value) {
         bitField0_ |= 0x00000002;
@@ -3195,8 +3607,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional bool is_assigned = 2;</code>
-       *
        * <pre>
        * This trip has been assigned to a physical train. If true, this trip is
        * already underway or most likely will depart shortly. 
@@ -3210,6 +3620,9 @@ public final class GtfsRealtimeNYCT {
        * to a storage location or assigned a nyct_train_id when a determination for
        * service is made.
        * </pre>
+       *
+       * <code>optional bool is_assigned = 2;</code>
+       * @return This builder for chaining.
        */
       public Builder clearIsAssigned() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -3218,10 +3631,8 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
 
-      private com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction direction_ = com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction.NORTH;
+      private int direction_ = 1;
       /**
-       * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
-       *
        * <pre>
        * Uptown and Bronx-bound trains are moving NORTH.
        * Times Square Shuttle to Grand Central is also northbound.
@@ -3230,13 +3641,14 @@ public final class GtfsRealtimeNYCT {
        * 
        * EAST and WEST are not used currently.
        * </pre>
+       *
+       * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
+       * @return Whether the direction field is set.
        */
       public boolean hasDirection() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
-       * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
-       *
        * <pre>
        * Uptown and Bronx-bound trains are moving NORTH.
        * Times Square Shuttle to Grand Central is also northbound.
@@ -3245,13 +3657,16 @@ public final class GtfsRealtimeNYCT {
        * 
        * EAST and WEST are not used currently.
        * </pre>
+       *
+       * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
+       * @return The direction.
        */
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction getDirection() {
-        return direction_;
+        @SuppressWarnings("deprecation")
+        com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction result = com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction.valueOf(direction_);
+        return result == null ? com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction.NORTH : result;
       }
       /**
-       * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
-       *
        * <pre>
        * Uptown and Bronx-bound trains are moving NORTH.
        * Times Square Shuttle to Grand Central is also northbound.
@@ -3260,19 +3675,21 @@ public final class GtfsRealtimeNYCT {
        * 
        * EAST and WEST are not used currently.
        * </pre>
+       *
+       * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
+       * @param value The direction to set.
+       * @return This builder for chaining.
        */
       public Builder setDirection(com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction value) {
         if (value == null) {
           throw new NullPointerException();
         }
         bitField0_ |= 0x00000004;
-        direction_ = value;
+        direction_ = value.getNumber();
         onChanged();
         return this;
       }
       /**
-       * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
-       *
        * <pre>
        * Uptown and Bronx-bound trains are moving NORTH.
        * Times Square Shuttle to Grand Central is also northbound.
@@ -3281,23 +3698,67 @@ public final class GtfsRealtimeNYCT {
        * 
        * EAST and WEST are not used currently.
        * </pre>
+       *
+       * <code>optional .transit_realtime.NyctTripDescriptor.Direction direction = 3;</code>
+       * @return This builder for chaining.
        */
       public Builder clearDirection() {
         bitField0_ = (bitField0_ & ~0x00000004);
-        direction_ = com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor.Direction.NORTH;
+        direction_ = 1;
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.NyctTripDescriptor)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.NyctTripDescriptor)
+    private static final com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor DEFAULT_INSTANCE;
     static {
-      defaultInstance = new NyctTripDescriptor(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.NyctTripDescriptor)
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<NyctTripDescriptor>
+        PARSER = new com.google.protobuf.AbstractParser<NyctTripDescriptor>() {
+      @java.lang.Override
+      public NyctTripDescriptor parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new NyctTripDescriptor(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<NyctTripDescriptor> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<NyctTripDescriptor> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeNYCT.NyctTripDescriptor getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface NyctStopTimeUpdateOrBuilder extends
@@ -3305,8 +3766,6 @@ public final class GtfsRealtimeNYCT {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional string scheduled_track = 1;</code>
-     *
      * <pre>
      * Provides the planned station arrival track. The following is the Manhattan
      * track configurations:
@@ -3322,11 +3781,12 @@ public final class GtfsRealtimeNYCT {
      * 2: northbound
      * 3: bi-directional
      * </pre>
+     *
+     * <code>optional string scheduled_track = 1;</code>
+     * @return Whether the scheduledTrack field is set.
      */
     boolean hasScheduledTrack();
     /**
-     * <code>optional string scheduled_track = 1;</code>
-     *
      * <pre>
      * Provides the planned station arrival track. The following is the Manhattan
      * track configurations:
@@ -3342,11 +3802,12 @@ public final class GtfsRealtimeNYCT {
      * 2: northbound
      * 3: bi-directional
      * </pre>
+     *
+     * <code>optional string scheduled_track = 1;</code>
+     * @return The scheduledTrack.
      */
     java.lang.String getScheduledTrack();
     /**
-     * <code>optional string scheduled_track = 1;</code>
-     *
      * <pre>
      * Provides the planned station arrival track. The following is the Manhattan
      * track configurations:
@@ -3362,13 +3823,14 @@ public final class GtfsRealtimeNYCT {
      * 2: northbound
      * 3: bi-directional
      * </pre>
+     *
+     * <code>optional string scheduled_track = 1;</code>
+     * @return The bytes for scheduledTrack.
      */
     com.google.protobuf.ByteString
         getScheduledTrackBytes();
 
     /**
-     * <code>optional string actual_track = 2;</code>
-     *
      * <pre>
      * This is the actual track that the train is operating on and can be used to
      * determine if a train is operating according to its current schedule
@@ -3384,11 +3846,12 @@ public final class GtfsRealtimeNYCT {
      * schedule.  The rules engine for the 'countdown' clocks will remove this
      * train from all schedule stations.
      * </pre>
+     *
+     * <code>optional string actual_track = 2;</code>
+     * @return Whether the actualTrack field is set.
      */
     boolean hasActualTrack();
     /**
-     * <code>optional string actual_track = 2;</code>
-     *
      * <pre>
      * This is the actual track that the train is operating on and can be used to
      * determine if a train is operating according to its current schedule
@@ -3404,11 +3867,12 @@ public final class GtfsRealtimeNYCT {
      * schedule.  The rules engine for the 'countdown' clocks will remove this
      * train from all schedule stations.
      * </pre>
+     *
+     * <code>optional string actual_track = 2;</code>
+     * @return The actualTrack.
      */
     java.lang.String getActualTrack();
     /**
-     * <code>optional string actual_track = 2;</code>
-     *
      * <pre>
      * This is the actual track that the train is operating on and can be used to
      * determine if a train is operating according to its current schedule
@@ -3424,48 +3888,54 @@ public final class GtfsRealtimeNYCT {
      * schedule.  The rules engine for the 'countdown' clocks will remove this
      * train from all schedule stations.
      * </pre>
+     *
+     * <code>optional string actual_track = 2;</code>
+     * @return The bytes for actualTrack.
      */
     com.google.protobuf.ByteString
         getActualTrackBytes();
   }
   /**
-   * Protobuf type {@code transit_realtime.NyctStopTimeUpdate}
-   *
    * <pre>
    * NYCT Subway extensions for the stop time update
    * </pre>
+   *
+   * Protobuf type {@code transit_realtime.NyctStopTimeUpdate}
    */
-  public static final class NyctStopTimeUpdate extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class NyctStopTimeUpdate extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.NyctStopTimeUpdate)
       NyctStopTimeUpdateOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use NyctStopTimeUpdate.newBuilder() to construct.
-    private NyctStopTimeUpdate(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private NyctStopTimeUpdate(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private NyctStopTimeUpdate(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final NyctStopTimeUpdate defaultInstance;
-    public static NyctStopTimeUpdate getDefaultInstance() {
-      return defaultInstance;
+    private NyctStopTimeUpdate() {
+      scheduledTrack_ = "";
+      actualTrack_ = "";
     }
 
-    public NyctStopTimeUpdate getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new NyctStopTimeUpdate();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private NyctStopTimeUpdate(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3477,13 +3947,6 @@ public final class GtfsRealtimeNYCT {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -3496,13 +3959,20 @@ public final class GtfsRealtimeNYCT {
               actualTrack_ = bs;
               break;
             }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -3513,34 +3983,18 @@ public final class GtfsRealtimeNYCT {
       return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctStopTimeUpdate_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctStopTimeUpdate_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate.class, com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<NyctStopTimeUpdate> PARSER =
-        new com.google.protobuf.AbstractParser<NyctStopTimeUpdate>() {
-      public NyctStopTimeUpdate parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new NyctStopTimeUpdate(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<NyctStopTimeUpdate> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int SCHEDULED_TRACK_FIELD_NUMBER = 1;
-    private java.lang.Object scheduledTrack_;
+    private volatile java.lang.Object scheduledTrack_;
     /**
-     * <code>optional string scheduled_track = 1;</code>
-     *
      * <pre>
      * Provides the planned station arrival track. The following is the Manhattan
      * track configurations:
@@ -3556,13 +4010,14 @@ public final class GtfsRealtimeNYCT {
      * 2: northbound
      * 3: bi-directional
      * </pre>
+     *
+     * <code>optional string scheduled_track = 1;</code>
+     * @return Whether the scheduledTrack field is set.
      */
     public boolean hasScheduledTrack() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>optional string scheduled_track = 1;</code>
-     *
      * <pre>
      * Provides the planned station arrival track. The following is the Manhattan
      * track configurations:
@@ -3578,6 +4033,9 @@ public final class GtfsRealtimeNYCT {
      * 2: northbound
      * 3: bi-directional
      * </pre>
+     *
+     * <code>optional string scheduled_track = 1;</code>
+     * @return The scheduledTrack.
      */
     public java.lang.String getScheduledTrack() {
       java.lang.Object ref = scheduledTrack_;
@@ -3594,8 +4052,6 @@ public final class GtfsRealtimeNYCT {
       }
     }
     /**
-     * <code>optional string scheduled_track = 1;</code>
-     *
      * <pre>
      * Provides the planned station arrival track. The following is the Manhattan
      * track configurations:
@@ -3611,6 +4067,9 @@ public final class GtfsRealtimeNYCT {
      * 2: northbound
      * 3: bi-directional
      * </pre>
+     *
+     * <code>optional string scheduled_track = 1;</code>
+     * @return The bytes for scheduledTrack.
      */
     public com.google.protobuf.ByteString
         getScheduledTrackBytes() {
@@ -3627,10 +4086,8 @@ public final class GtfsRealtimeNYCT {
     }
 
     public static final int ACTUAL_TRACK_FIELD_NUMBER = 2;
-    private java.lang.Object actualTrack_;
+    private volatile java.lang.Object actualTrack_;
     /**
-     * <code>optional string actual_track = 2;</code>
-     *
      * <pre>
      * This is the actual track that the train is operating on and can be used to
      * determine if a train is operating according to its current schedule
@@ -3646,13 +4103,14 @@ public final class GtfsRealtimeNYCT {
      * schedule.  The rules engine for the 'countdown' clocks will remove this
      * train from all schedule stations.
      * </pre>
+     *
+     * <code>optional string actual_track = 2;</code>
+     * @return Whether the actualTrack field is set.
      */
     public boolean hasActualTrack() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     * <code>optional string actual_track = 2;</code>
-     *
      * <pre>
      * This is the actual track that the train is operating on and can be used to
      * determine if a train is operating according to its current schedule
@@ -3668,6 +4126,9 @@ public final class GtfsRealtimeNYCT {
      * schedule.  The rules engine for the 'countdown' clocks will remove this
      * train from all schedule stations.
      * </pre>
+     *
+     * <code>optional string actual_track = 2;</code>
+     * @return The actualTrack.
      */
     public java.lang.String getActualTrack() {
       java.lang.Object ref = actualTrack_;
@@ -3684,8 +4145,6 @@ public final class GtfsRealtimeNYCT {
       }
     }
     /**
-     * <code>optional string actual_track = 2;</code>
-     *
      * <pre>
      * This is the actual track that the train is operating on and can be used to
      * determine if a train is operating according to its current schedule
@@ -3701,6 +4160,9 @@ public final class GtfsRealtimeNYCT {
      * schedule.  The rules engine for the 'countdown' clocks will remove this
      * train from all schedule stations.
      * </pre>
+     *
+     * <code>optional string actual_track = 2;</code>
+     * @return The bytes for actualTrack.
      */
     public com.google.protobuf.ByteString
         getActualTrackBytes() {
@@ -3716,11 +4178,8 @@ public final class GtfsRealtimeNYCT {
       }
     }
 
-    private void initFields() {
-      scheduledTrack_ = "";
-      actualTrack_ = "";
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3730,44 +4189,90 @@ public final class GtfsRealtimeNYCT {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getScheduledTrackBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, scheduledTrack_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(2, getActualTrackBytes());
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, actualTrack_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getScheduledTrackBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, scheduledTrack_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(2, getActualTrackBytes());
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, actualTrack_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate other = (com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate) obj;
+
+      if (hasScheduledTrack() != other.hasScheduledTrack()) return false;
+      if (hasScheduledTrack()) {
+        if (!getScheduledTrack()
+            .equals(other.getScheduledTrack())) return false;
+      }
+      if (hasActualTrack() != other.hasActualTrack()) return false;
+      if (hasActualTrack()) {
+        if (!getActualTrack()
+            .equals(other.getActualTrack())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasScheduledTrack()) {
+        hash = (37 * hash) + SCHEDULED_TRACK_FIELD_NUMBER;
+        hash = (53 * hash) + getScheduledTrack().hashCode();
+      }
+      if (hasActualTrack()) {
+        hash = (37 * hash) + ACTUAL_TRACK_FIELD_NUMBER;
+        hash = (53 * hash) + getActualTrack().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -3791,58 +4296,71 @@ public final class GtfsRealtimeNYCT {
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /**
-     * Protobuf type {@code transit_realtime.NyctStopTimeUpdate}
-     *
      * <pre>
      * NYCT Subway extensions for the stop time update
      * </pre>
+     *
+     * Protobuf type {@code transit_realtime.NyctStopTimeUpdate}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.NyctStopTimeUpdate)
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdateOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -3850,7 +4368,8 @@ public final class GtfsRealtimeNYCT {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctStopTimeUpdate_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctStopTimeUpdate_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -3863,18 +4382,16 @@ public final class GtfsRealtimeNYCT {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         scheduledTrack_ = "";
@@ -3884,19 +4401,18 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.internal_static_transit_realtime_NyctStopTimeUpdate_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate build() {
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate result = buildPartial();
         if (!result.isInitialized()) {
@@ -3905,15 +4421,16 @@ public final class GtfsRealtimeNYCT {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate buildPartial() {
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate result = new com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.scheduledTrack_ = scheduledTrack_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.actualTrack_ = actualTrack_;
@@ -3922,6 +4439,39 @@ public final class GtfsRealtimeNYCT {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate)other);
@@ -3943,14 +4493,17 @@ public final class GtfsRealtimeNYCT {
           actualTrack_ = other.actualTrack_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3960,7 +4513,7 @@ public final class GtfsRealtimeNYCT {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -3972,8 +4525,6 @@ public final class GtfsRealtimeNYCT {
 
       private java.lang.Object scheduledTrack_ = "";
       /**
-       * <code>optional string scheduled_track = 1;</code>
-       *
        * <pre>
        * Provides the planned station arrival track. The following is the Manhattan
        * track configurations:
@@ -3989,13 +4540,14 @@ public final class GtfsRealtimeNYCT {
        * 2: northbound
        * 3: bi-directional
        * </pre>
+       *
+       * <code>optional string scheduled_track = 1;</code>
+       * @return Whether the scheduledTrack field is set.
        */
       public boolean hasScheduledTrack() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>optional string scheduled_track = 1;</code>
-       *
        * <pre>
        * Provides the planned station arrival track. The following is the Manhattan
        * track configurations:
@@ -4011,6 +4563,9 @@ public final class GtfsRealtimeNYCT {
        * 2: northbound
        * 3: bi-directional
        * </pre>
+       *
+       * <code>optional string scheduled_track = 1;</code>
+       * @return The scheduledTrack.
        */
       public java.lang.String getScheduledTrack() {
         java.lang.Object ref = scheduledTrack_;
@@ -4027,8 +4582,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>optional string scheduled_track = 1;</code>
-       *
        * <pre>
        * Provides the planned station arrival track. The following is the Manhattan
        * track configurations:
@@ -4044,6 +4597,9 @@ public final class GtfsRealtimeNYCT {
        * 2: northbound
        * 3: bi-directional
        * </pre>
+       *
+       * <code>optional string scheduled_track = 1;</code>
+       * @return The bytes for scheduledTrack.
        */
       public com.google.protobuf.ByteString
           getScheduledTrackBytes() {
@@ -4059,8 +4615,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>optional string scheduled_track = 1;</code>
-       *
        * <pre>
        * Provides the planned station arrival track. The following is the Manhattan
        * track configurations:
@@ -4076,6 +4630,10 @@ public final class GtfsRealtimeNYCT {
        * 2: northbound
        * 3: bi-directional
        * </pre>
+       *
+       * <code>optional string scheduled_track = 1;</code>
+       * @param value The scheduledTrack to set.
+       * @return This builder for chaining.
        */
       public Builder setScheduledTrack(
           java.lang.String value) {
@@ -4088,8 +4646,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional string scheduled_track = 1;</code>
-       *
        * <pre>
        * Provides the planned station arrival track. The following is the Manhattan
        * track configurations:
@@ -4105,6 +4661,9 @@ public final class GtfsRealtimeNYCT {
        * 2: northbound
        * 3: bi-directional
        * </pre>
+       *
+       * <code>optional string scheduled_track = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearScheduledTrack() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -4113,8 +4672,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional string scheduled_track = 1;</code>
-       *
        * <pre>
        * Provides the planned station arrival track. The following is the Manhattan
        * track configurations:
@@ -4130,6 +4687,10 @@ public final class GtfsRealtimeNYCT {
        * 2: northbound
        * 3: bi-directional
        * </pre>
+       *
+       * <code>optional string scheduled_track = 1;</code>
+       * @param value The bytes for scheduledTrack to set.
+       * @return This builder for chaining.
        */
       public Builder setScheduledTrackBytes(
           com.google.protobuf.ByteString value) {
@@ -4144,8 +4705,6 @@ public final class GtfsRealtimeNYCT {
 
       private java.lang.Object actualTrack_ = "";
       /**
-       * <code>optional string actual_track = 2;</code>
-       *
        * <pre>
        * This is the actual track that the train is operating on and can be used to
        * determine if a train is operating according to its current schedule
@@ -4161,13 +4720,14 @@ public final class GtfsRealtimeNYCT {
        * schedule.  The rules engine for the 'countdown' clocks will remove this
        * train from all schedule stations.
        * </pre>
+       *
+       * <code>optional string actual_track = 2;</code>
+       * @return Whether the actualTrack field is set.
        */
       public boolean hasActualTrack() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
-       * <code>optional string actual_track = 2;</code>
-       *
        * <pre>
        * This is the actual track that the train is operating on and can be used to
        * determine if a train is operating according to its current schedule
@@ -4183,6 +4743,9 @@ public final class GtfsRealtimeNYCT {
        * schedule.  The rules engine for the 'countdown' clocks will remove this
        * train from all schedule stations.
        * </pre>
+       *
+       * <code>optional string actual_track = 2;</code>
+       * @return The actualTrack.
        */
       public java.lang.String getActualTrack() {
         java.lang.Object ref = actualTrack_;
@@ -4199,8 +4762,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>optional string actual_track = 2;</code>
-       *
        * <pre>
        * This is the actual track that the train is operating on and can be used to
        * determine if a train is operating according to its current schedule
@@ -4216,6 +4777,9 @@ public final class GtfsRealtimeNYCT {
        * schedule.  The rules engine for the 'countdown' clocks will remove this
        * train from all schedule stations.
        * </pre>
+       *
+       * <code>optional string actual_track = 2;</code>
+       * @return The bytes for actualTrack.
        */
       public com.google.protobuf.ByteString
           getActualTrackBytes() {
@@ -4231,8 +4795,6 @@ public final class GtfsRealtimeNYCT {
         }
       }
       /**
-       * <code>optional string actual_track = 2;</code>
-       *
        * <pre>
        * This is the actual track that the train is operating on and can be used to
        * determine if a train is operating according to its current schedule
@@ -4248,6 +4810,10 @@ public final class GtfsRealtimeNYCT {
        * schedule.  The rules engine for the 'countdown' clocks will remove this
        * train from all schedule stations.
        * </pre>
+       *
+       * <code>optional string actual_track = 2;</code>
+       * @param value The actualTrack to set.
+       * @return This builder for chaining.
        */
       public Builder setActualTrack(
           java.lang.String value) {
@@ -4260,8 +4826,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional string actual_track = 2;</code>
-       *
        * <pre>
        * This is the actual track that the train is operating on and can be used to
        * determine if a train is operating according to its current schedule
@@ -4277,6 +4841,9 @@ public final class GtfsRealtimeNYCT {
        * schedule.  The rules engine for the 'countdown' clocks will remove this
        * train from all schedule stations.
        * </pre>
+       *
+       * <code>optional string actual_track = 2;</code>
+       * @return This builder for chaining.
        */
       public Builder clearActualTrack() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -4285,8 +4852,6 @@ public final class GtfsRealtimeNYCT {
         return this;
       }
       /**
-       * <code>optional string actual_track = 2;</code>
-       *
        * <pre>
        * This is the actual track that the train is operating on and can be used to
        * determine if a train is operating according to its current schedule
@@ -4302,6 +4867,10 @@ public final class GtfsRealtimeNYCT {
        * schedule.  The rules engine for the 'countdown' clocks will remove this
        * train from all schedule stations.
        * </pre>
+       *
+       * <code>optional string actual_track = 2;</code>
+       * @param value The bytes for actualTrack to set.
+       * @return This builder for chaining.
        */
       public Builder setActualTrackBytes(
           com.google.protobuf.ByteString value) {
@@ -4313,16 +4882,57 @@ public final class GtfsRealtimeNYCT {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.NyctStopTimeUpdate)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.NyctStopTimeUpdate)
+    private static final com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate DEFAULT_INSTANCE;
     static {
-      defaultInstance = new NyctStopTimeUpdate(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.NyctStopTimeUpdate)
+    public static com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<NyctStopTimeUpdate>
+        PARSER = new com.google.protobuf.AbstractParser<NyctStopTimeUpdate>() {
+      @java.lang.Override
+      public NyctStopTimeUpdate parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new NyctStopTimeUpdate(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<NyctStopTimeUpdate> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<NyctStopTimeUpdate> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public static final int NYCT_FEED_HEADER_FIELD_NUMBER = 1001;
@@ -4360,30 +4970,30 @@ public final class GtfsRealtimeNYCT {
         com.google.transit.realtime.GtfsRealtimeNYCT.NyctStopTimeUpdate.getDefaultInstance());
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_TripReplacementPeriod_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_TripReplacementPeriod_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_NyctFeedHeader_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_NyctFeedHeader_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_NyctTripDescriptor_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_NyctTripDescriptor_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_NyctStopTimeUpdate_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_NyctStopTimeUpdate_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
   }
-  private static com.google.protobuf.Descriptors.FileDescriptor
+  private static  com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
     java.lang.String[] descriptorData = {
@@ -4396,7 +5006,7 @@ public final class GtfsRealtimeNYCT {
       "\033\n\023nyct_subway_version\030\001 \002(\t\022H\n\027trip_rep" +
       "lacement_period\030\002 \003(\0132\'.transit_realtime" +
       ".TripReplacementPeriod\"\265\001\n\022NyctTripDescr" +
-      "iptor\022\020\n\010train_id\030\001 \001(\t\022\023\n\013is_assigned\030\002",
+      "iptor\022\020\n\010train_id\030\001 \001(\t\022\023\n\013is_assigned\030\002" +
       " \001(\010\022A\n\tdirection\030\003 \001(\0162..transit_realti" +
       "me.NyctTripDescriptor.Direction\"5\n\tDirec" +
       "tion\022\t\n\005NORTH\020\001\022\010\n\004EAST\020\002\022\t\n\005SOUTH\020\003\022\010\n\004" +
@@ -4406,47 +5016,39 @@ public final class GtfsRealtimeNYCT {
       "eader\030\351\007 \001(\0132 .transit_realtime.NyctFeed" +
       "Header:e\n\024nyct_trip_descriptor\022 .transit" +
       "_realtime.TripDescriptor\030\351\007 \001(\0132$.transi" +
-      "t_realtime.NyctTripDescriptor:q\n\025nyct_st",
+      "t_realtime.NyctTripDescriptor:q\n\025nyct_st" +
       "op_time_update\022+.transit_realtime.TripUp" +
       "date.StopTimeUpdate\030\351\007 \001(\0132$.transit_rea" +
       "ltime.NyctStopTimeUpdateB\035\n\033com.google.t" +
       "ransit.realtime"
     };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
+    descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.transit.realtime.GtfsRealtime.getDescriptor(),
-        }, assigner);
+        });
     internal_static_transit_realtime_TripReplacementPeriod_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_transit_realtime_TripReplacementPeriod_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_TripReplacementPeriod_descriptor,
         new java.lang.String[] { "RouteId", "ReplacementPeriod", });
     internal_static_transit_realtime_NyctFeedHeader_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_transit_realtime_NyctFeedHeader_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_NyctFeedHeader_descriptor,
         new java.lang.String[] { "NyctSubwayVersion", "TripReplacementPeriod", });
     internal_static_transit_realtime_NyctTripDescriptor_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_transit_realtime_NyctTripDescriptor_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_NyctTripDescriptor_descriptor,
         new java.lang.String[] { "TrainId", "IsAssigned", "Direction", });
     internal_static_transit_realtime_NyctStopTimeUpdate_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_transit_realtime_NyctStopTimeUpdate_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_NyctStopTimeUpdate_descriptor,
         new java.lang.String[] { "ScheduledTrack", "ActualTrack", });
     nyctFeedHeader.internalInit(descriptor.getExtensions().get(0));

--- a/src/main/java/com/google/transit/realtime/GtfsRealtimeOneBusAway.java
+++ b/src/main/java/com/google/transit/realtime/GtfsRealtimeOneBusAway.java
@@ -38,20 +38,24 @@ package com.google.transit.realtime;
 public final class GtfsRealtimeOneBusAway {
   private GtfsRealtimeOneBusAway() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
     registry.add(com.google.transit.realtime.GtfsRealtimeOneBusAway.obaFeedHeader);
     registry.add(com.google.transit.realtime.GtfsRealtimeOneBusAway.obaFeedEntity);
     registry.add(com.google.transit.realtime.GtfsRealtimeOneBusAway.obaTripUpdate);
     registry.add(com.google.transit.realtime.GtfsRealtimeOneBusAway.obaStopTimeUpdate);
     registry.add(com.google.transit.realtime.GtfsRealtimeOneBusAway.obaEntitySelector);
   }
+
+  public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
+  }
   public interface OneBusAwayFeedHeaderOrBuilder extends
       // @@protoc_insertion_point(interface_extends:transit_realtime.OneBusAwayFeedHeader)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional uint64 incremental_index = 1;</code>
-     *
      * <pre>
      * For an incremental feed, the index of the current incremental FeedMessage.
      * Each incremental FeedMessage sent to a client should sequentially
@@ -59,11 +63,12 @@ public final class GtfsRealtimeOneBusAway {
      * looking for gaps in the index value.  It is not required that the index
      * of the first message sent to a client be zero.
      * </pre>
+     *
+     * <code>optional uint64 incremental_index = 1;</code>
+     * @return Whether the incrementalIndex field is set.
      */
     boolean hasIncrementalIndex();
     /**
-     * <code>optional uint64 incremental_index = 1;</code>
-     *
      * <pre>
      * For an incremental feed, the index of the current incremental FeedMessage.
      * Each incremental FeedMessage sent to a client should sequentially
@@ -71,66 +76,72 @@ public final class GtfsRealtimeOneBusAway {
      * looking for gaps in the index value.  It is not required that the index
      * of the first message sent to a client be zero.
      * </pre>
+     *
+     * <code>optional uint64 incremental_index = 1;</code>
+     * @return The incrementalIndex.
      */
     long getIncrementalIndex();
 
     /**
-     * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
-     *
      * <pre>
      * For an incremental feed, the maximum amount of time, in seconds, between
      * incremental updates.  Clients that have not received a FeedMessage, empty
      * or otherwise, in the specified time interval should assume that the
      * connection has been lost and reconnect.
      * </pre>
+     *
+     * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
+     * @return Whether the incrementalHeartbeatInterval field is set.
      */
     boolean hasIncrementalHeartbeatInterval();
     /**
-     * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
-     *
      * <pre>
      * For an incremental feed, the maximum amount of time, in seconds, between
      * incremental updates.  Clients that have not received a FeedMessage, empty
      * or otherwise, in the specified time interval should assume that the
      * connection has been lost and reconnect.
      * </pre>
+     *
+     * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
+     * @return The incrementalHeartbeatInterval.
      */
     int getIncrementalHeartbeatInterval();
   }
   /**
    * Protobuf type {@code transit_realtime.OneBusAwayFeedHeader}
    */
-  public static final class OneBusAwayFeedHeader extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class OneBusAwayFeedHeader extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.OneBusAwayFeedHeader)
       OneBusAwayFeedHeaderOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use OneBusAwayFeedHeader.newBuilder() to construct.
-    private OneBusAwayFeedHeader(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private OneBusAwayFeedHeader(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private OneBusAwayFeedHeader(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final OneBusAwayFeedHeader defaultInstance;
-    public static OneBusAwayFeedHeader getDefaultInstance() {
-      return defaultInstance;
+    private OneBusAwayFeedHeader() {
     }
 
-    public OneBusAwayFeedHeader getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new OneBusAwayFeedHeader();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private OneBusAwayFeedHeader(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -142,13 +153,6 @@ public final class GtfsRealtimeOneBusAway {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 8: {
               bitField0_ |= 0x00000001;
               incrementalIndex_ = input.readUInt64();
@@ -159,13 +163,20 @@ public final class GtfsRealtimeOneBusAway {
               incrementalHeartbeatInterval_ = input.readUInt32();
               break;
             }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -176,34 +187,18 @@ public final class GtfsRealtimeOneBusAway {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedHeader_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedHeader_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader.class, com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<OneBusAwayFeedHeader> PARSER =
-        new com.google.protobuf.AbstractParser<OneBusAwayFeedHeader>() {
-      public OneBusAwayFeedHeader parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new OneBusAwayFeedHeader(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<OneBusAwayFeedHeader> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int INCREMENTAL_INDEX_FIELD_NUMBER = 1;
     private long incrementalIndex_;
     /**
-     * <code>optional uint64 incremental_index = 1;</code>
-     *
      * <pre>
      * For an incremental feed, the index of the current incremental FeedMessage.
      * Each incremental FeedMessage sent to a client should sequentially
@@ -211,13 +206,14 @@ public final class GtfsRealtimeOneBusAway {
      * looking for gaps in the index value.  It is not required that the index
      * of the first message sent to a client be zero.
      * </pre>
+     *
+     * <code>optional uint64 incremental_index = 1;</code>
+     * @return Whether the incrementalIndex field is set.
      */
     public boolean hasIncrementalIndex() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>optional uint64 incremental_index = 1;</code>
-     *
      * <pre>
      * For an incremental feed, the index of the current incremental FeedMessage.
      * Each incremental FeedMessage sent to a client should sequentially
@@ -225,6 +221,9 @@ public final class GtfsRealtimeOneBusAway {
      * looking for gaps in the index value.  It is not required that the index
      * of the first message sent to a client be zero.
      * </pre>
+     *
+     * <code>optional uint64 incremental_index = 1;</code>
+     * @return The incrementalIndex.
      */
     public long getIncrementalIndex() {
       return incrementalIndex_;
@@ -233,37 +232,36 @@ public final class GtfsRealtimeOneBusAway {
     public static final int INCREMENTAL_HEARTBEAT_INTERVAL_FIELD_NUMBER = 2;
     private int incrementalHeartbeatInterval_;
     /**
-     * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
-     *
      * <pre>
      * For an incremental feed, the maximum amount of time, in seconds, between
      * incremental updates.  Clients that have not received a FeedMessage, empty
      * or otherwise, in the specified time interval should assume that the
      * connection has been lost and reconnect.
      * </pre>
+     *
+     * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
+     * @return Whether the incrementalHeartbeatInterval field is set.
      */
     public boolean hasIncrementalHeartbeatInterval() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
-     *
      * <pre>
      * For an incremental feed, the maximum amount of time, in seconds, between
      * incremental updates.  Clients that have not received a FeedMessage, empty
      * or otherwise, in the specified time interval should assume that the
      * connection has been lost and reconnect.
      * </pre>
+     *
+     * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
+     * @return The incrementalHeartbeatInterval.
      */
     public int getIncrementalHeartbeatInterval() {
       return incrementalHeartbeatInterval_;
     }
 
-    private void initFields() {
-      incrementalIndex_ = 0L;
-      incrementalHeartbeatInterval_ = 0;
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -273,44 +271,93 @@ public final class GtfsRealtimeOneBusAway {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeUInt64(1, incrementalIndex_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeUInt32(2, incrementalHeartbeatInterval_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(1, incrementalIndex_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt32Size(2, incrementalHeartbeatInterval_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader other = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader) obj;
+
+      if (hasIncrementalIndex() != other.hasIncrementalIndex()) return false;
+      if (hasIncrementalIndex()) {
+        if (getIncrementalIndex()
+            != other.getIncrementalIndex()) return false;
+      }
+      if (hasIncrementalHeartbeatInterval() != other.hasIncrementalHeartbeatInterval()) return false;
+      if (hasIncrementalHeartbeatInterval()) {
+        if (getIncrementalHeartbeatInterval()
+            != other.getIncrementalHeartbeatInterval()) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasIncrementalIndex()) {
+        hash = (37 * hash) + INCREMENTAL_INDEX_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getIncrementalIndex());
+      }
+      if (hasIncrementalHeartbeatInterval()) {
+        hash = (37 * hash) + INCREMENTAL_HEARTBEAT_INTERVAL_FIELD_NUMBER;
+        hash = (53 * hash) + getIncrementalHeartbeatInterval();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -334,46 +381,59 @@ public final class GtfsRealtimeOneBusAway {
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -381,7 +441,7 @@ public final class GtfsRealtimeOneBusAway {
      * Protobuf type {@code transit_realtime.OneBusAwayFeedHeader}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.OneBusAwayFeedHeader)
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeaderOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -389,7 +449,8 @@ public final class GtfsRealtimeOneBusAway {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedHeader_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedHeader_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -402,18 +463,16 @@ public final class GtfsRealtimeOneBusAway {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         incrementalIndex_ = 0L;
@@ -423,19 +482,18 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedHeader_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader build() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader result = buildPartial();
         if (!result.isInitialized()) {
@@ -444,23 +502,57 @@ public final class GtfsRealtimeOneBusAway {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader buildPartial() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader result = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.incrementalIndex_ = incrementalIndex_;
           to_bitField0_ |= 0x00000001;
         }
-        result.incrementalIndex_ = incrementalIndex_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.incrementalHeartbeatInterval_ = incrementalHeartbeatInterval_;
           to_bitField0_ |= 0x00000002;
         }
-        result.incrementalHeartbeatInterval_ = incrementalHeartbeatInterval_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader)other);
@@ -478,14 +570,17 @@ public final class GtfsRealtimeOneBusAway {
         if (other.hasIncrementalHeartbeatInterval()) {
           setIncrementalHeartbeatInterval(other.getIncrementalHeartbeatInterval());
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -495,7 +590,7 @@ public final class GtfsRealtimeOneBusAway {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -507,8 +602,6 @@ public final class GtfsRealtimeOneBusAway {
 
       private long incrementalIndex_ ;
       /**
-       * <code>optional uint64 incremental_index = 1;</code>
-       *
        * <pre>
        * For an incremental feed, the index of the current incremental FeedMessage.
        * Each incremental FeedMessage sent to a client should sequentially
@@ -516,13 +609,14 @@ public final class GtfsRealtimeOneBusAway {
        * looking for gaps in the index value.  It is not required that the index
        * of the first message sent to a client be zero.
        * </pre>
+       *
+       * <code>optional uint64 incremental_index = 1;</code>
+       * @return Whether the incrementalIndex field is set.
        */
       public boolean hasIncrementalIndex() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>optional uint64 incremental_index = 1;</code>
-       *
        * <pre>
        * For an incremental feed, the index of the current incremental FeedMessage.
        * Each incremental FeedMessage sent to a client should sequentially
@@ -530,13 +624,14 @@ public final class GtfsRealtimeOneBusAway {
        * looking for gaps in the index value.  It is not required that the index
        * of the first message sent to a client be zero.
        * </pre>
+       *
+       * <code>optional uint64 incremental_index = 1;</code>
+       * @return The incrementalIndex.
        */
       public long getIncrementalIndex() {
         return incrementalIndex_;
       }
       /**
-       * <code>optional uint64 incremental_index = 1;</code>
-       *
        * <pre>
        * For an incremental feed, the index of the current incremental FeedMessage.
        * Each incremental FeedMessage sent to a client should sequentially
@@ -544,6 +639,10 @@ public final class GtfsRealtimeOneBusAway {
        * looking for gaps in the index value.  It is not required that the index
        * of the first message sent to a client be zero.
        * </pre>
+       *
+       * <code>optional uint64 incremental_index = 1;</code>
+       * @param value The incrementalIndex to set.
+       * @return This builder for chaining.
        */
       public Builder setIncrementalIndex(long value) {
         bitField0_ |= 0x00000001;
@@ -552,8 +651,6 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional uint64 incremental_index = 1;</code>
-       *
        * <pre>
        * For an incremental feed, the index of the current incremental FeedMessage.
        * Each incremental FeedMessage sent to a client should sequentially
@@ -561,6 +658,9 @@ public final class GtfsRealtimeOneBusAway {
        * looking for gaps in the index value.  It is not required that the index
        * of the first message sent to a client be zero.
        * </pre>
+       *
+       * <code>optional uint64 incremental_index = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearIncrementalIndex() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -571,40 +671,44 @@ public final class GtfsRealtimeOneBusAway {
 
       private int incrementalHeartbeatInterval_ ;
       /**
-       * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
-       *
        * <pre>
        * For an incremental feed, the maximum amount of time, in seconds, between
        * incremental updates.  Clients that have not received a FeedMessage, empty
        * or otherwise, in the specified time interval should assume that the
        * connection has been lost and reconnect.
        * </pre>
+       *
+       * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
+       * @return Whether the incrementalHeartbeatInterval field is set.
        */
       public boolean hasIncrementalHeartbeatInterval() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
-       * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
-       *
        * <pre>
        * For an incremental feed, the maximum amount of time, in seconds, between
        * incremental updates.  Clients that have not received a FeedMessage, empty
        * or otherwise, in the specified time interval should assume that the
        * connection has been lost and reconnect.
        * </pre>
+       *
+       * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
+       * @return The incrementalHeartbeatInterval.
        */
       public int getIncrementalHeartbeatInterval() {
         return incrementalHeartbeatInterval_;
       }
       /**
-       * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
-       *
        * <pre>
        * For an incremental feed, the maximum amount of time, in seconds, between
        * incremental updates.  Clients that have not received a FeedMessage, empty
        * or otherwise, in the specified time interval should assume that the
        * connection has been lost and reconnect.
        * </pre>
+       *
+       * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
+       * @param value The incrementalHeartbeatInterval to set.
+       * @return This builder for chaining.
        */
       public Builder setIncrementalHeartbeatInterval(int value) {
         bitField0_ |= 0x00000002;
@@ -613,14 +717,15 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
-       *
        * <pre>
        * For an incremental feed, the maximum amount of time, in seconds, between
        * incremental updates.  Clients that have not received a FeedMessage, empty
        * or otherwise, in the specified time interval should assume that the
        * connection has been lost and reconnect.
        * </pre>
+       *
+       * <code>optional uint32 incremental_heartbeat_interval = 2;</code>
+       * @return This builder for chaining.
        */
       public Builder clearIncrementalHeartbeatInterval() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -628,16 +733,57 @@ public final class GtfsRealtimeOneBusAway {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.OneBusAwayFeedHeader)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayFeedHeader)
+    private static final com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader DEFAULT_INSTANCE;
     static {
-      defaultInstance = new OneBusAwayFeedHeader(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayFeedHeader)
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<OneBusAwayFeedHeader>
+        PARSER = new com.google.protobuf.AbstractParser<OneBusAwayFeedHeader>() {
+      @java.lang.Override
+      public OneBusAwayFeedHeader parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new OneBusAwayFeedHeader(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<OneBusAwayFeedHeader> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<OneBusAwayFeedHeader> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedHeader getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface OneBusAwayFeedEntityOrBuilder extends
@@ -645,27 +791,30 @@ public final class GtfsRealtimeOneBusAway {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional string source = 1;</code>
-     *
      * <pre>
      * Optional description of the source of a particular feed entity.
      * </pre>
+     *
+     * <code>optional string source = 1;</code>
+     * @return Whether the source field is set.
      */
     boolean hasSource();
     /**
-     * <code>optional string source = 1;</code>
-     *
      * <pre>
      * Optional description of the source of a particular feed entity.
      * </pre>
+     *
+     * <code>optional string source = 1;</code>
+     * @return The source.
      */
     java.lang.String getSource();
     /**
-     * <code>optional string source = 1;</code>
-     *
      * <pre>
      * Optional description of the source of a particular feed entity.
      * </pre>
+     *
+     * <code>optional string source = 1;</code>
+     * @return The bytes for source.
      */
     com.google.protobuf.ByteString
         getSourceBytes();
@@ -673,37 +822,39 @@ public final class GtfsRealtimeOneBusAway {
   /**
    * Protobuf type {@code transit_realtime.OneBusAwayFeedEntity}
    */
-  public static final class OneBusAwayFeedEntity extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class OneBusAwayFeedEntity extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.OneBusAwayFeedEntity)
       OneBusAwayFeedEntityOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use OneBusAwayFeedEntity.newBuilder() to construct.
-    private OneBusAwayFeedEntity(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private OneBusAwayFeedEntity(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private OneBusAwayFeedEntity(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final OneBusAwayFeedEntity defaultInstance;
-    public static OneBusAwayFeedEntity getDefaultInstance() {
-      return defaultInstance;
+    private OneBusAwayFeedEntity() {
+      source_ = "";
     }
 
-    public OneBusAwayFeedEntity getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new OneBusAwayFeedEntity();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private OneBusAwayFeedEntity(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -715,17 +866,17 @@ public final class GtfsRealtimeOneBusAway {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
               source_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
               break;
             }
           }
@@ -734,7 +885,7 @@ public final class GtfsRealtimeOneBusAway {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -745,47 +896,35 @@ public final class GtfsRealtimeOneBusAway {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedEntity_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedEntity_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity.class, com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<OneBusAwayFeedEntity> PARSER =
-        new com.google.protobuf.AbstractParser<OneBusAwayFeedEntity>() {
-      public OneBusAwayFeedEntity parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new OneBusAwayFeedEntity(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<OneBusAwayFeedEntity> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int SOURCE_FIELD_NUMBER = 1;
-    private java.lang.Object source_;
+    private volatile java.lang.Object source_;
     /**
-     * <code>optional string source = 1;</code>
-     *
      * <pre>
      * Optional description of the source of a particular feed entity.
      * </pre>
+     *
+     * <code>optional string source = 1;</code>
+     * @return Whether the source field is set.
      */
     public boolean hasSource() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>optional string source = 1;</code>
-     *
      * <pre>
      * Optional description of the source of a particular feed entity.
      * </pre>
+     *
+     * <code>optional string source = 1;</code>
+     * @return The source.
      */
     public java.lang.String getSource() {
       java.lang.Object ref = source_;
@@ -802,11 +941,12 @@ public final class GtfsRealtimeOneBusAway {
       }
     }
     /**
-     * <code>optional string source = 1;</code>
-     *
      * <pre>
      * Optional description of the source of a particular feed entity.
      * </pre>
+     *
+     * <code>optional string source = 1;</code>
+     * @return The bytes for source.
      */
     public com.google.protobuf.ByteString
         getSourceBytes() {
@@ -822,10 +962,8 @@ public final class GtfsRealtimeOneBusAway {
       }
     }
 
-    private void initFields() {
-      source_ = "";
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -835,37 +973,75 @@ public final class GtfsRealtimeOneBusAway {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getSourceBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, source_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getSourceBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, source_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity other = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity) obj;
+
+      if (hasSource() != other.hasSource()) return false;
+      if (hasSource()) {
+        if (!getSource()
+            .equals(other.getSource())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasSource()) {
+        hash = (37 * hash) + SOURCE_FIELD_NUMBER;
+        hash = (53 * hash) + getSource().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -889,46 +1065,59 @@ public final class GtfsRealtimeOneBusAway {
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -936,7 +1125,7 @@ public final class GtfsRealtimeOneBusAway {
      * Protobuf type {@code transit_realtime.OneBusAwayFeedEntity}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.OneBusAwayFeedEntity)
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntityOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -944,7 +1133,8 @@ public final class GtfsRealtimeOneBusAway {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedEntity_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedEntity_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -957,18 +1147,16 @@ public final class GtfsRealtimeOneBusAway {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         source_ = "";
@@ -976,19 +1164,18 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayFeedEntity_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity build() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity result = buildPartial();
         if (!result.isInitialized()) {
@@ -997,11 +1184,12 @@ public final class GtfsRealtimeOneBusAway {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity buildPartial() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity result = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.source_ = source_;
@@ -1010,6 +1198,39 @@ public final class GtfsRealtimeOneBusAway {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity)other);
@@ -1026,14 +1247,17 @@ public final class GtfsRealtimeOneBusAway {
           source_ = other.source_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1043,7 +1267,7 @@ public final class GtfsRealtimeOneBusAway {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1055,21 +1279,23 @@ public final class GtfsRealtimeOneBusAway {
 
       private java.lang.Object source_ = "";
       /**
-       * <code>optional string source = 1;</code>
-       *
        * <pre>
        * Optional description of the source of a particular feed entity.
        * </pre>
+       *
+       * <code>optional string source = 1;</code>
+       * @return Whether the source field is set.
        */
       public boolean hasSource() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>optional string source = 1;</code>
-       *
        * <pre>
        * Optional description of the source of a particular feed entity.
        * </pre>
+       *
+       * <code>optional string source = 1;</code>
+       * @return The source.
        */
       public java.lang.String getSource() {
         java.lang.Object ref = source_;
@@ -1086,11 +1312,12 @@ public final class GtfsRealtimeOneBusAway {
         }
       }
       /**
-       * <code>optional string source = 1;</code>
-       *
        * <pre>
        * Optional description of the source of a particular feed entity.
        * </pre>
+       *
+       * <code>optional string source = 1;</code>
+       * @return The bytes for source.
        */
       public com.google.protobuf.ByteString
           getSourceBytes() {
@@ -1106,11 +1333,13 @@ public final class GtfsRealtimeOneBusAway {
         }
       }
       /**
-       * <code>optional string source = 1;</code>
-       *
        * <pre>
        * Optional description of the source of a particular feed entity.
        * </pre>
+       *
+       * <code>optional string source = 1;</code>
+       * @param value The source to set.
+       * @return This builder for chaining.
        */
       public Builder setSource(
           java.lang.String value) {
@@ -1123,11 +1352,12 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional string source = 1;</code>
-       *
        * <pre>
        * Optional description of the source of a particular feed entity.
        * </pre>
+       *
+       * <code>optional string source = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearSource() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -1136,11 +1366,13 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional string source = 1;</code>
-       *
        * <pre>
        * Optional description of the source of a particular feed entity.
        * </pre>
+       *
+       * <code>optional string source = 1;</code>
+       * @param value The bytes for source to set.
+       * @return This builder for chaining.
        */
       public Builder setSourceBytes(
           com.google.protobuf.ByteString value) {
@@ -1152,16 +1384,57 @@ public final class GtfsRealtimeOneBusAway {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.OneBusAwayFeedEntity)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayFeedEntity)
+    private static final com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity DEFAULT_INSTANCE;
     static {
-      defaultInstance = new OneBusAwayFeedEntity(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayFeedEntity)
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<OneBusAwayFeedEntity>
+        PARSER = new com.google.protobuf.AbstractParser<OneBusAwayFeedEntity>() {
+      @java.lang.Override
+      public OneBusAwayFeedEntity parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new OneBusAwayFeedEntity(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<OneBusAwayFeedEntity> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<OneBusAwayFeedEntity> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayFeedEntity getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface OneBusAwayTripUpdateOrBuilder extends
@@ -1169,97 +1442,107 @@ public final class GtfsRealtimeOneBusAway {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional int32 delay = 1 [deprecated = true];</code>
-     *
      * <pre>
      * Delay (in seconds) can be positive (meaning that the vehicle is late) or
      * negative (meaning that the vehicle is ahead of schedule). Delay of 0
      * means that the vehicle is exactly on time.
      * Deprecated in favor of TripUpdate.delay
      * </pre>
+     *
+     * <code>optional int32 delay = 1 [deprecated = true];</code>
+     * @return Whether the delay field is set.
      */
     @java.lang.Deprecated boolean hasDelay();
     /**
-     * <code>optional int32 delay = 1 [deprecated = true];</code>
-     *
      * <pre>
      * Delay (in seconds) can be positive (meaning that the vehicle is late) or
      * negative (meaning that the vehicle is ahead of schedule). Delay of 0
      * means that the vehicle is exactly on time.
      * Deprecated in favor of TripUpdate.delay
      * </pre>
+     *
+     * <code>optional int32 delay = 1 [deprecated = true];</code>
+     * @return The delay.
      */
     @java.lang.Deprecated int getDelay();
 
     /**
-     * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
-     *
      * <pre>
      * Moment at which the trip update was computed. In POSIX time
      * (i.e., number of seconds since January 1st 1970 00:00:00 UTC).
      * Deprecated in favor of TripUpdate.timestamp
      * </pre>
+     *
+     * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
+     * @return Whether the timestamp field is set.
      */
     @java.lang.Deprecated boolean hasTimestamp();
     /**
-     * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
-     *
      * <pre>
      * Moment at which the trip update was computed. In POSIX time
      * (i.e., number of seconds since January 1st 1970 00:00:00 UTC).
      * Deprecated in favor of TripUpdate.timestamp
      * </pre>
+     *
+     * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
+     * @return The timestamp.
      */
     @java.lang.Deprecated long getTimestamp();
 
     /**
-     * <code>optional string tripHeadsign = 3;</code>
-     *
      * <pre>
      * trip headsign
      * </pre>
+     *
+     * <code>optional string tripHeadsign = 3;</code>
+     * @return Whether the tripHeadsign field is set.
      */
     boolean hasTripHeadsign();
     /**
-     * <code>optional string tripHeadsign = 3;</code>
-     *
      * <pre>
      * trip headsign
      * </pre>
+     *
+     * <code>optional string tripHeadsign = 3;</code>
+     * @return The tripHeadsign.
      */
     java.lang.String getTripHeadsign();
     /**
-     * <code>optional string tripHeadsign = 3;</code>
-     *
      * <pre>
      * trip headsign
      * </pre>
+     *
+     * <code>optional string tripHeadsign = 3;</code>
+     * @return The bytes for tripHeadsign.
      */
     com.google.protobuf.ByteString
         getTripHeadsignBytes();
 
     /**
-     * <code>optional string tripDirection = 4;</code>
-     *
      * <pre>
      * trip direction
      * </pre>
+     *
+     * <code>optional string tripDirection = 4;</code>
+     * @return Whether the tripDirection field is set.
      */
     boolean hasTripDirection();
     /**
-     * <code>optional string tripDirection = 4;</code>
-     *
      * <pre>
      * trip direction
      * </pre>
+     *
+     * <code>optional string tripDirection = 4;</code>
+     * @return The tripDirection.
      */
     java.lang.String getTripDirection();
     /**
-     * <code>optional string tripDirection = 4;</code>
-     *
      * <pre>
      * trip direction
      * </pre>
+     *
+     * <code>optional string tripDirection = 4;</code>
+     * @return The bytes for tripDirection.
      */
     com.google.protobuf.ByteString
         getTripDirectionBytes();
@@ -1267,37 +1550,40 @@ public final class GtfsRealtimeOneBusAway {
   /**
    * Protobuf type {@code transit_realtime.OneBusAwayTripUpdate}
    */
-  public static final class OneBusAwayTripUpdate extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class OneBusAwayTripUpdate extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.OneBusAwayTripUpdate)
       OneBusAwayTripUpdateOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use OneBusAwayTripUpdate.newBuilder() to construct.
-    private OneBusAwayTripUpdate(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private OneBusAwayTripUpdate(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private OneBusAwayTripUpdate(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final OneBusAwayTripUpdate defaultInstance;
-    public static OneBusAwayTripUpdate getDefaultInstance() {
-      return defaultInstance;
+    private OneBusAwayTripUpdate() {
+      tripHeadsign_ = "";
+      tripDirection_ = "";
     }
 
-    public OneBusAwayTripUpdate getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new OneBusAwayTripUpdate();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private OneBusAwayTripUpdate(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1309,13 +1595,6 @@ public final class GtfsRealtimeOneBusAway {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 8: {
               bitField0_ |= 0x00000001;
               delay_ = input.readInt32();
@@ -1338,13 +1617,20 @@ public final class GtfsRealtimeOneBusAway {
               tripDirection_ = bs;
               break;
             }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -1355,53 +1641,41 @@ public final class GtfsRealtimeOneBusAway {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayTripUpdate_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayTripUpdate_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate.class, com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<OneBusAwayTripUpdate> PARSER =
-        new com.google.protobuf.AbstractParser<OneBusAwayTripUpdate>() {
-      public OneBusAwayTripUpdate parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new OneBusAwayTripUpdate(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<OneBusAwayTripUpdate> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int DELAY_FIELD_NUMBER = 1;
     private int delay_;
     /**
-     * <code>optional int32 delay = 1 [deprecated = true];</code>
-     *
      * <pre>
      * Delay (in seconds) can be positive (meaning that the vehicle is late) or
      * negative (meaning that the vehicle is ahead of schedule). Delay of 0
      * means that the vehicle is exactly on time.
      * Deprecated in favor of TripUpdate.delay
      * </pre>
+     *
+     * <code>optional int32 delay = 1 [deprecated = true];</code>
+     * @return Whether the delay field is set.
      */
     @java.lang.Deprecated public boolean hasDelay() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>optional int32 delay = 1 [deprecated = true];</code>
-     *
      * <pre>
      * Delay (in seconds) can be positive (meaning that the vehicle is late) or
      * negative (meaning that the vehicle is ahead of schedule). Delay of 0
      * means that the vehicle is exactly on time.
      * Deprecated in favor of TripUpdate.delay
      * </pre>
+     *
+     * <code>optional int32 delay = 1 [deprecated = true];</code>
+     * @return The delay.
      */
     @java.lang.Deprecated public int getDelay() {
       return delay_;
@@ -1410,48 +1684,52 @@ public final class GtfsRealtimeOneBusAway {
     public static final int TIMESTAMP_FIELD_NUMBER = 2;
     private long timestamp_;
     /**
-     * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
-     *
      * <pre>
      * Moment at which the trip update was computed. In POSIX time
      * (i.e., number of seconds since January 1st 1970 00:00:00 UTC).
      * Deprecated in favor of TripUpdate.timestamp
      * </pre>
+     *
+     * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
+     * @return Whether the timestamp field is set.
      */
     @java.lang.Deprecated public boolean hasTimestamp() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
-     * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
-     *
      * <pre>
      * Moment at which the trip update was computed. In POSIX time
      * (i.e., number of seconds since January 1st 1970 00:00:00 UTC).
      * Deprecated in favor of TripUpdate.timestamp
      * </pre>
+     *
+     * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
+     * @return The timestamp.
      */
     @java.lang.Deprecated public long getTimestamp() {
       return timestamp_;
     }
 
     public static final int TRIPHEADSIGN_FIELD_NUMBER = 3;
-    private java.lang.Object tripHeadsign_;
+    private volatile java.lang.Object tripHeadsign_;
     /**
-     * <code>optional string tripHeadsign = 3;</code>
-     *
      * <pre>
      * trip headsign
      * </pre>
+     *
+     * <code>optional string tripHeadsign = 3;</code>
+     * @return Whether the tripHeadsign field is set.
      */
     public boolean hasTripHeadsign() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
-     * <code>optional string tripHeadsign = 3;</code>
-     *
      * <pre>
      * trip headsign
      * </pre>
+     *
+     * <code>optional string tripHeadsign = 3;</code>
+     * @return The tripHeadsign.
      */
     public java.lang.String getTripHeadsign() {
       java.lang.Object ref = tripHeadsign_;
@@ -1468,11 +1746,12 @@ public final class GtfsRealtimeOneBusAway {
       }
     }
     /**
-     * <code>optional string tripHeadsign = 3;</code>
-     *
      * <pre>
      * trip headsign
      * </pre>
+     *
+     * <code>optional string tripHeadsign = 3;</code>
+     * @return The bytes for tripHeadsign.
      */
     public com.google.protobuf.ByteString
         getTripHeadsignBytes() {
@@ -1489,23 +1768,25 @@ public final class GtfsRealtimeOneBusAway {
     }
 
     public static final int TRIPDIRECTION_FIELD_NUMBER = 4;
-    private java.lang.Object tripDirection_;
+    private volatile java.lang.Object tripDirection_;
     /**
-     * <code>optional string tripDirection = 4;</code>
-     *
      * <pre>
      * trip direction
      * </pre>
+     *
+     * <code>optional string tripDirection = 4;</code>
+     * @return Whether the tripDirection field is set.
      */
     public boolean hasTripDirection() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
-     * <code>optional string tripDirection = 4;</code>
-     *
      * <pre>
      * trip direction
      * </pre>
+     *
+     * <code>optional string tripDirection = 4;</code>
+     * @return The tripDirection.
      */
     public java.lang.String getTripDirection() {
       java.lang.Object ref = tripDirection_;
@@ -1522,11 +1803,12 @@ public final class GtfsRealtimeOneBusAway {
       }
     }
     /**
-     * <code>optional string tripDirection = 4;</code>
-     *
      * <pre>
      * trip direction
      * </pre>
+     *
+     * <code>optional string tripDirection = 4;</code>
+     * @return The bytes for tripDirection.
      */
     public com.google.protobuf.ByteString
         getTripDirectionBytes() {
@@ -1542,13 +1824,8 @@ public final class GtfsRealtimeOneBusAway {
       }
     }
 
-    private void initFields() {
-      delay_ = 0;
-      timestamp_ = 0L;
-      tripHeadsign_ = "";
-      tripDirection_ = "";
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1558,58 +1835,123 @@ public final class GtfsRealtimeOneBusAway {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeInt32(1, delay_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeUInt64(2, timestamp_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeBytes(3, getTripHeadsignBytes());
+      if (((bitField0_ & 0x00000004) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, tripHeadsign_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeBytes(4, getTripDirectionBytes());
+      if (((bitField0_ & 0x00000008) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, tripDirection_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(1, delay_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, timestamp_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(3, getTripHeadsignBytes());
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, tripHeadsign_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(4, getTripDirectionBytes());
+      if (((bitField0_ & 0x00000008) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, tripDirection_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate other = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate) obj;
+
+      if (hasDelay() != other.hasDelay()) return false;
+      if (hasDelay()) {
+        if (getDelay()
+            != other.getDelay()) return false;
+      }
+      if (hasTimestamp() != other.hasTimestamp()) return false;
+      if (hasTimestamp()) {
+        if (getTimestamp()
+            != other.getTimestamp()) return false;
+      }
+      if (hasTripHeadsign() != other.hasTripHeadsign()) return false;
+      if (hasTripHeadsign()) {
+        if (!getTripHeadsign()
+            .equals(other.getTripHeadsign())) return false;
+      }
+      if (hasTripDirection() != other.hasTripDirection()) return false;
+      if (hasTripDirection()) {
+        if (!getTripDirection()
+            .equals(other.getTripDirection())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasDelay()) {
+        hash = (37 * hash) + DELAY_FIELD_NUMBER;
+        hash = (53 * hash) + getDelay();
+      }
+      if (hasTimestamp()) {
+        hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getTimestamp());
+      }
+      if (hasTripHeadsign()) {
+        hash = (37 * hash) + TRIPHEADSIGN_FIELD_NUMBER;
+        hash = (53 * hash) + getTripHeadsign().hashCode();
+      }
+      if (hasTripDirection()) {
+        hash = (37 * hash) + TRIPDIRECTION_FIELD_NUMBER;
+        hash = (53 * hash) + getTripDirection().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -1633,46 +1975,59 @@ public final class GtfsRealtimeOneBusAway {
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1680,7 +2035,7 @@ public final class GtfsRealtimeOneBusAway {
      * Protobuf type {@code transit_realtime.OneBusAwayTripUpdate}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.OneBusAwayTripUpdate)
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdateOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1688,7 +2043,8 @@ public final class GtfsRealtimeOneBusAway {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayTripUpdate_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayTripUpdate_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1701,18 +2057,16 @@ public final class GtfsRealtimeOneBusAway {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         delay_ = 0;
@@ -1726,19 +2080,18 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayTripUpdate_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate build() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate result = buildPartial();
         if (!result.isInitialized()) {
@@ -1747,23 +2100,24 @@ public final class GtfsRealtimeOneBusAway {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate buildPartial() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate result = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.delay_ = delay_;
           to_bitField0_ |= 0x00000001;
         }
-        result.delay_ = delay_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.timestamp_ = timestamp_;
           to_bitField0_ |= 0x00000002;
         }
-        result.timestamp_ = timestamp_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.tripHeadsign_ = tripHeadsign_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.tripDirection_ = tripDirection_;
@@ -1772,6 +2126,39 @@ public final class GtfsRealtimeOneBusAway {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate)other);
@@ -1799,14 +2186,17 @@ public final class GtfsRealtimeOneBusAway {
           tripDirection_ = other.tripDirection_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1816,7 +2206,7 @@ public final class GtfsRealtimeOneBusAway {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1828,40 +2218,44 @@ public final class GtfsRealtimeOneBusAway {
 
       private int delay_ ;
       /**
-       * <code>optional int32 delay = 1 [deprecated = true];</code>
-       *
        * <pre>
        * Delay (in seconds) can be positive (meaning that the vehicle is late) or
        * negative (meaning that the vehicle is ahead of schedule). Delay of 0
        * means that the vehicle is exactly on time.
        * Deprecated in favor of TripUpdate.delay
        * </pre>
+       *
+       * <code>optional int32 delay = 1 [deprecated = true];</code>
+       * @return Whether the delay field is set.
        */
       @java.lang.Deprecated public boolean hasDelay() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>optional int32 delay = 1 [deprecated = true];</code>
-       *
        * <pre>
        * Delay (in seconds) can be positive (meaning that the vehicle is late) or
        * negative (meaning that the vehicle is ahead of schedule). Delay of 0
        * means that the vehicle is exactly on time.
        * Deprecated in favor of TripUpdate.delay
        * </pre>
+       *
+       * <code>optional int32 delay = 1 [deprecated = true];</code>
+       * @return The delay.
        */
       @java.lang.Deprecated public int getDelay() {
         return delay_;
       }
       /**
-       * <code>optional int32 delay = 1 [deprecated = true];</code>
-       *
        * <pre>
        * Delay (in seconds) can be positive (meaning that the vehicle is late) or
        * negative (meaning that the vehicle is ahead of schedule). Delay of 0
        * means that the vehicle is exactly on time.
        * Deprecated in favor of TripUpdate.delay
        * </pre>
+       *
+       * <code>optional int32 delay = 1 [deprecated = true];</code>
+       * @param value The delay to set.
+       * @return This builder for chaining.
        */
       @java.lang.Deprecated public Builder setDelay(int value) {
         bitField0_ |= 0x00000001;
@@ -1870,14 +2264,15 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional int32 delay = 1 [deprecated = true];</code>
-       *
        * <pre>
        * Delay (in seconds) can be positive (meaning that the vehicle is late) or
        * negative (meaning that the vehicle is ahead of schedule). Delay of 0
        * means that the vehicle is exactly on time.
        * Deprecated in favor of TripUpdate.delay
        * </pre>
+       *
+       * <code>optional int32 delay = 1 [deprecated = true];</code>
+       * @return This builder for chaining.
        */
       @java.lang.Deprecated public Builder clearDelay() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -1888,37 +2283,41 @@ public final class GtfsRealtimeOneBusAway {
 
       private long timestamp_ ;
       /**
-       * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
-       *
        * <pre>
        * Moment at which the trip update was computed. In POSIX time
        * (i.e., number of seconds since January 1st 1970 00:00:00 UTC).
        * Deprecated in favor of TripUpdate.timestamp
        * </pre>
+       *
+       * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
+       * @return Whether the timestamp field is set.
        */
       @java.lang.Deprecated public boolean hasTimestamp() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
-       * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
-       *
        * <pre>
        * Moment at which the trip update was computed. In POSIX time
        * (i.e., number of seconds since January 1st 1970 00:00:00 UTC).
        * Deprecated in favor of TripUpdate.timestamp
        * </pre>
+       *
+       * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
+       * @return The timestamp.
        */
       @java.lang.Deprecated public long getTimestamp() {
         return timestamp_;
       }
       /**
-       * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
-       *
        * <pre>
        * Moment at which the trip update was computed. In POSIX time
        * (i.e., number of seconds since January 1st 1970 00:00:00 UTC).
        * Deprecated in favor of TripUpdate.timestamp
        * </pre>
+       *
+       * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
+       * @param value The timestamp to set.
+       * @return This builder for chaining.
        */
       @java.lang.Deprecated public Builder setTimestamp(long value) {
         bitField0_ |= 0x00000002;
@@ -1927,13 +2326,14 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
-       *
        * <pre>
        * Moment at which the trip update was computed. In POSIX time
        * (i.e., number of seconds since January 1st 1970 00:00:00 UTC).
        * Deprecated in favor of TripUpdate.timestamp
        * </pre>
+       *
+       * <code>optional uint64 timestamp = 2 [deprecated = true];</code>
+       * @return This builder for chaining.
        */
       @java.lang.Deprecated public Builder clearTimestamp() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -1944,21 +2344,23 @@ public final class GtfsRealtimeOneBusAway {
 
       private java.lang.Object tripHeadsign_ = "";
       /**
-       * <code>optional string tripHeadsign = 3;</code>
-       *
        * <pre>
        * trip headsign
        * </pre>
+       *
+       * <code>optional string tripHeadsign = 3;</code>
+       * @return Whether the tripHeadsign field is set.
        */
       public boolean hasTripHeadsign() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
-       * <code>optional string tripHeadsign = 3;</code>
-       *
        * <pre>
        * trip headsign
        * </pre>
+       *
+       * <code>optional string tripHeadsign = 3;</code>
+       * @return The tripHeadsign.
        */
       public java.lang.String getTripHeadsign() {
         java.lang.Object ref = tripHeadsign_;
@@ -1975,11 +2377,12 @@ public final class GtfsRealtimeOneBusAway {
         }
       }
       /**
-       * <code>optional string tripHeadsign = 3;</code>
-       *
        * <pre>
        * trip headsign
        * </pre>
+       *
+       * <code>optional string tripHeadsign = 3;</code>
+       * @return The bytes for tripHeadsign.
        */
       public com.google.protobuf.ByteString
           getTripHeadsignBytes() {
@@ -1995,11 +2398,13 @@ public final class GtfsRealtimeOneBusAway {
         }
       }
       /**
-       * <code>optional string tripHeadsign = 3;</code>
-       *
        * <pre>
        * trip headsign
        * </pre>
+       *
+       * <code>optional string tripHeadsign = 3;</code>
+       * @param value The tripHeadsign to set.
+       * @return This builder for chaining.
        */
       public Builder setTripHeadsign(
           java.lang.String value) {
@@ -2012,11 +2417,12 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional string tripHeadsign = 3;</code>
-       *
        * <pre>
        * trip headsign
        * </pre>
+       *
+       * <code>optional string tripHeadsign = 3;</code>
+       * @return This builder for chaining.
        */
       public Builder clearTripHeadsign() {
         bitField0_ = (bitField0_ & ~0x00000004);
@@ -2025,11 +2431,13 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional string tripHeadsign = 3;</code>
-       *
        * <pre>
        * trip headsign
        * </pre>
+       *
+       * <code>optional string tripHeadsign = 3;</code>
+       * @param value The bytes for tripHeadsign to set.
+       * @return This builder for chaining.
        */
       public Builder setTripHeadsignBytes(
           com.google.protobuf.ByteString value) {
@@ -2044,21 +2452,23 @@ public final class GtfsRealtimeOneBusAway {
 
       private java.lang.Object tripDirection_ = "";
       /**
-       * <code>optional string tripDirection = 4;</code>
-       *
        * <pre>
        * trip direction
        * </pre>
+       *
+       * <code>optional string tripDirection = 4;</code>
+       * @return Whether the tripDirection field is set.
        */
       public boolean hasTripDirection() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
-       * <code>optional string tripDirection = 4;</code>
-       *
        * <pre>
        * trip direction
        * </pre>
+       *
+       * <code>optional string tripDirection = 4;</code>
+       * @return The tripDirection.
        */
       public java.lang.String getTripDirection() {
         java.lang.Object ref = tripDirection_;
@@ -2075,11 +2485,12 @@ public final class GtfsRealtimeOneBusAway {
         }
       }
       /**
-       * <code>optional string tripDirection = 4;</code>
-       *
        * <pre>
        * trip direction
        * </pre>
+       *
+       * <code>optional string tripDirection = 4;</code>
+       * @return The bytes for tripDirection.
        */
       public com.google.protobuf.ByteString
           getTripDirectionBytes() {
@@ -2095,11 +2506,13 @@ public final class GtfsRealtimeOneBusAway {
         }
       }
       /**
-       * <code>optional string tripDirection = 4;</code>
-       *
        * <pre>
        * trip direction
        * </pre>
+       *
+       * <code>optional string tripDirection = 4;</code>
+       * @param value The tripDirection to set.
+       * @return This builder for chaining.
        */
       public Builder setTripDirection(
           java.lang.String value) {
@@ -2112,11 +2525,12 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional string tripDirection = 4;</code>
-       *
        * <pre>
        * trip direction
        * </pre>
+       *
+       * <code>optional string tripDirection = 4;</code>
+       * @return This builder for chaining.
        */
       public Builder clearTripDirection() {
         bitField0_ = (bitField0_ & ~0x00000008);
@@ -2125,11 +2539,13 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
       /**
-       * <code>optional string tripDirection = 4;</code>
-       *
        * <pre>
        * trip direction
        * </pre>
+       *
+       * <code>optional string tripDirection = 4;</code>
+       * @param value The bytes for tripDirection to set.
+       * @return This builder for chaining.
        */
       public Builder setTripDirectionBytes(
           com.google.protobuf.ByteString value) {
@@ -2141,16 +2557,57 @@ public final class GtfsRealtimeOneBusAway {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.OneBusAwayTripUpdate)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayTripUpdate)
+    private static final com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate DEFAULT_INSTANCE;
     static {
-      defaultInstance = new OneBusAwayTripUpdate(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayTripUpdate)
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<OneBusAwayTripUpdate>
+        PARSER = new com.google.protobuf.AbstractParser<OneBusAwayTripUpdate>() {
+      @java.lang.Override
+      public OneBusAwayTripUpdate parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new OneBusAwayTripUpdate(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<OneBusAwayTripUpdate> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<OneBusAwayTripUpdate> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface OneBusAwayStopTimeUpdateOrBuilder extends
@@ -2159,14 +2616,17 @@ public final class GtfsRealtimeOneBusAway {
 
     /**
      * <code>optional string stopHeadsign = 1;</code>
+     * @return Whether the stopHeadsign field is set.
      */
     boolean hasStopHeadsign();
     /**
      * <code>optional string stopHeadsign = 1;</code>
+     * @return The stopHeadsign.
      */
     java.lang.String getStopHeadsign();
     /**
      * <code>optional string stopHeadsign = 1;</code>
+     * @return The bytes for stopHeadsign.
      */
     com.google.protobuf.ByteString
         getStopHeadsignBytes();
@@ -2174,37 +2634,39 @@ public final class GtfsRealtimeOneBusAway {
   /**
    * Protobuf type {@code transit_realtime.OneBusAwayStopTimeUpdate}
    */
-  public static final class OneBusAwayStopTimeUpdate extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class OneBusAwayStopTimeUpdate extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.OneBusAwayStopTimeUpdate)
       OneBusAwayStopTimeUpdateOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use OneBusAwayStopTimeUpdate.newBuilder() to construct.
-    private OneBusAwayStopTimeUpdate(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private OneBusAwayStopTimeUpdate(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private OneBusAwayStopTimeUpdate(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final OneBusAwayStopTimeUpdate defaultInstance;
-    public static OneBusAwayStopTimeUpdate getDefaultInstance() {
-      return defaultInstance;
+    private OneBusAwayStopTimeUpdate() {
+      stopHeadsign_ = "";
     }
 
-    public OneBusAwayStopTimeUpdate getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new OneBusAwayStopTimeUpdate();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private OneBusAwayStopTimeUpdate(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2216,17 +2678,17 @@ public final class GtfsRealtimeOneBusAway {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
               stopHeadsign_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
               break;
             }
           }
@@ -2235,7 +2697,7 @@ public final class GtfsRealtimeOneBusAway {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -2246,39 +2708,27 @@ public final class GtfsRealtimeOneBusAway {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayStopTimeUpdate_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayStopTimeUpdate_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate.class, com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<OneBusAwayStopTimeUpdate> PARSER =
-        new com.google.protobuf.AbstractParser<OneBusAwayStopTimeUpdate>() {
-      public OneBusAwayStopTimeUpdate parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new OneBusAwayStopTimeUpdate(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<OneBusAwayStopTimeUpdate> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int STOPHEADSIGN_FIELD_NUMBER = 1;
-    private java.lang.Object stopHeadsign_;
+    private volatile java.lang.Object stopHeadsign_;
     /**
      * <code>optional string stopHeadsign = 1;</code>
+     * @return Whether the stopHeadsign field is set.
      */
     public boolean hasStopHeadsign() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional string stopHeadsign = 1;</code>
+     * @return The stopHeadsign.
      */
     public java.lang.String getStopHeadsign() {
       java.lang.Object ref = stopHeadsign_;
@@ -2296,6 +2746,7 @@ public final class GtfsRealtimeOneBusAway {
     }
     /**
      * <code>optional string stopHeadsign = 1;</code>
+     * @return The bytes for stopHeadsign.
      */
     public com.google.protobuf.ByteString
         getStopHeadsignBytes() {
@@ -2311,10 +2762,8 @@ public final class GtfsRealtimeOneBusAway {
       }
     }
 
-    private void initFields() {
-      stopHeadsign_ = "";
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2324,37 +2773,75 @@ public final class GtfsRealtimeOneBusAway {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getStopHeadsignBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, stopHeadsign_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getStopHeadsignBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, stopHeadsign_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate other = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate) obj;
+
+      if (hasStopHeadsign() != other.hasStopHeadsign()) return false;
+      if (hasStopHeadsign()) {
+        if (!getStopHeadsign()
+            .equals(other.getStopHeadsign())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasStopHeadsign()) {
+        hash = (37 * hash) + STOPHEADSIGN_FIELD_NUMBER;
+        hash = (53 * hash) + getStopHeadsign().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2378,46 +2865,59 @@ public final class GtfsRealtimeOneBusAway {
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2425,7 +2925,7 @@ public final class GtfsRealtimeOneBusAway {
      * Protobuf type {@code transit_realtime.OneBusAwayStopTimeUpdate}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.OneBusAwayStopTimeUpdate)
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdateOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -2433,7 +2933,8 @@ public final class GtfsRealtimeOneBusAway {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayStopTimeUpdate_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayStopTimeUpdate_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2446,18 +2947,16 @@ public final class GtfsRealtimeOneBusAway {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         stopHeadsign_ = "";
@@ -2465,19 +2964,18 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayStopTimeUpdate_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate build() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate result = buildPartial();
         if (!result.isInitialized()) {
@@ -2486,11 +2984,12 @@ public final class GtfsRealtimeOneBusAway {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate buildPartial() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate result = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.stopHeadsign_ = stopHeadsign_;
@@ -2499,6 +2998,39 @@ public final class GtfsRealtimeOneBusAway {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate)other);
@@ -2515,14 +3047,17 @@ public final class GtfsRealtimeOneBusAway {
           stopHeadsign_ = other.stopHeadsign_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2532,7 +3067,7 @@ public final class GtfsRealtimeOneBusAway {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -2545,12 +3080,14 @@ public final class GtfsRealtimeOneBusAway {
       private java.lang.Object stopHeadsign_ = "";
       /**
        * <code>optional string stopHeadsign = 1;</code>
+       * @return Whether the stopHeadsign field is set.
        */
       public boolean hasStopHeadsign() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional string stopHeadsign = 1;</code>
+       * @return The stopHeadsign.
        */
       public java.lang.String getStopHeadsign() {
         java.lang.Object ref = stopHeadsign_;
@@ -2568,6 +3105,7 @@ public final class GtfsRealtimeOneBusAway {
       }
       /**
        * <code>optional string stopHeadsign = 1;</code>
+       * @return The bytes for stopHeadsign.
        */
       public com.google.protobuf.ByteString
           getStopHeadsignBytes() {
@@ -2584,6 +3122,8 @@ public final class GtfsRealtimeOneBusAway {
       }
       /**
        * <code>optional string stopHeadsign = 1;</code>
+       * @param value The stopHeadsign to set.
+       * @return This builder for chaining.
        */
       public Builder setStopHeadsign(
           java.lang.String value) {
@@ -2597,6 +3137,7 @@ public final class GtfsRealtimeOneBusAway {
       }
       /**
        * <code>optional string stopHeadsign = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearStopHeadsign() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -2606,6 +3147,8 @@ public final class GtfsRealtimeOneBusAway {
       }
       /**
        * <code>optional string stopHeadsign = 1;</code>
+       * @param value The bytes for stopHeadsign to set.
+       * @return This builder for chaining.
        */
       public Builder setStopHeadsignBytes(
           com.google.protobuf.ByteString value) {
@@ -2617,16 +3160,57 @@ public final class GtfsRealtimeOneBusAway {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.OneBusAwayStopTimeUpdate)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayStopTimeUpdate)
+    private static final com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate DEFAULT_INSTANCE;
     static {
-      defaultInstance = new OneBusAwayStopTimeUpdate(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayStopTimeUpdate)
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<OneBusAwayStopTimeUpdate>
+        PARSER = new com.google.protobuf.AbstractParser<OneBusAwayStopTimeUpdate>() {
+      @java.lang.Override
+      public OneBusAwayStopTimeUpdate parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new OneBusAwayStopTimeUpdate(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<OneBusAwayStopTimeUpdate> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<OneBusAwayStopTimeUpdate> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayStopTimeUpdate getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface OneBusAwayEntitySelectorOrBuilder extends
@@ -2635,14 +3219,17 @@ public final class GtfsRealtimeOneBusAway {
 
     /**
      * <code>optional string elevatorId = 1;</code>
+     * @return Whether the elevatorId field is set.
      */
     boolean hasElevatorId();
     /**
      * <code>optional string elevatorId = 1;</code>
+     * @return The elevatorId.
      */
     java.lang.String getElevatorId();
     /**
      * <code>optional string elevatorId = 1;</code>
+     * @return The bytes for elevatorId.
      */
     com.google.protobuf.ByteString
         getElevatorIdBytes();
@@ -2650,37 +3237,39 @@ public final class GtfsRealtimeOneBusAway {
   /**
    * Protobuf type {@code transit_realtime.OneBusAwayEntitySelector}
    */
-  public static final class OneBusAwayEntitySelector extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class OneBusAwayEntitySelector extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.OneBusAwayEntitySelector)
       OneBusAwayEntitySelectorOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use OneBusAwayEntitySelector.newBuilder() to construct.
-    private OneBusAwayEntitySelector(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private OneBusAwayEntitySelector(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private OneBusAwayEntitySelector(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final OneBusAwayEntitySelector defaultInstance;
-    public static OneBusAwayEntitySelector getDefaultInstance() {
-      return defaultInstance;
+    private OneBusAwayEntitySelector() {
+      elevatorId_ = "";
     }
 
-    public OneBusAwayEntitySelector getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new OneBusAwayEntitySelector();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private OneBusAwayEntitySelector(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2692,17 +3281,17 @@ public final class GtfsRealtimeOneBusAway {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
               elevatorId_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
               break;
             }
           }
@@ -2711,7 +3300,7 @@ public final class GtfsRealtimeOneBusAway {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -2722,39 +3311,27 @@ public final class GtfsRealtimeOneBusAway {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayEntitySelector_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayEntitySelector_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector.class, com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<OneBusAwayEntitySelector> PARSER =
-        new com.google.protobuf.AbstractParser<OneBusAwayEntitySelector>() {
-      public OneBusAwayEntitySelector parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new OneBusAwayEntitySelector(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<OneBusAwayEntitySelector> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int ELEVATORID_FIELD_NUMBER = 1;
-    private java.lang.Object elevatorId_;
+    private volatile java.lang.Object elevatorId_;
     /**
      * <code>optional string elevatorId = 1;</code>
+     * @return Whether the elevatorId field is set.
      */
     public boolean hasElevatorId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional string elevatorId = 1;</code>
+     * @return The elevatorId.
      */
     public java.lang.String getElevatorId() {
       java.lang.Object ref = elevatorId_;
@@ -2772,6 +3349,7 @@ public final class GtfsRealtimeOneBusAway {
     }
     /**
      * <code>optional string elevatorId = 1;</code>
+     * @return The bytes for elevatorId.
      */
     public com.google.protobuf.ByteString
         getElevatorIdBytes() {
@@ -2787,10 +3365,8 @@ public final class GtfsRealtimeOneBusAway {
       }
     }
 
-    private void initFields() {
-      elevatorId_ = "";
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2800,37 +3376,75 @@ public final class GtfsRealtimeOneBusAway {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getElevatorIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, elevatorId_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getElevatorIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, elevatorId_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector other = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector) obj;
+
+      if (hasElevatorId() != other.hasElevatorId()) return false;
+      if (hasElevatorId()) {
+        if (!getElevatorId()
+            .equals(other.getElevatorId())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasElevatorId()) {
+        hash = (37 * hash) + ELEVATORID_FIELD_NUMBER;
+        hash = (53 * hash) + getElevatorId().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2854,46 +3468,59 @@ public final class GtfsRealtimeOneBusAway {
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2901,7 +3528,7 @@ public final class GtfsRealtimeOneBusAway {
      * Protobuf type {@code transit_realtime.OneBusAwayEntitySelector}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.OneBusAwayEntitySelector)
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelectorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -2909,7 +3536,8 @@ public final class GtfsRealtimeOneBusAway {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayEntitySelector_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayEntitySelector_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2922,18 +3550,16 @@ public final class GtfsRealtimeOneBusAway {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         elevatorId_ = "";
@@ -2941,19 +3567,18 @@ public final class GtfsRealtimeOneBusAway {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.internal_static_transit_realtime_OneBusAwayEntitySelector_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector build() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector result = buildPartial();
         if (!result.isInitialized()) {
@@ -2962,11 +3587,12 @@ public final class GtfsRealtimeOneBusAway {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector buildPartial() {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector result = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.elevatorId_ = elevatorId_;
@@ -2975,6 +3601,39 @@ public final class GtfsRealtimeOneBusAway {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector)other);
@@ -2991,14 +3650,17 @@ public final class GtfsRealtimeOneBusAway {
           elevatorId_ = other.elevatorId_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3008,7 +3670,7 @@ public final class GtfsRealtimeOneBusAway {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -3021,12 +3683,14 @@ public final class GtfsRealtimeOneBusAway {
       private java.lang.Object elevatorId_ = "";
       /**
        * <code>optional string elevatorId = 1;</code>
+       * @return Whether the elevatorId field is set.
        */
       public boolean hasElevatorId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional string elevatorId = 1;</code>
+       * @return The elevatorId.
        */
       public java.lang.String getElevatorId() {
         java.lang.Object ref = elevatorId_;
@@ -3044,6 +3708,7 @@ public final class GtfsRealtimeOneBusAway {
       }
       /**
        * <code>optional string elevatorId = 1;</code>
+       * @return The bytes for elevatorId.
        */
       public com.google.protobuf.ByteString
           getElevatorIdBytes() {
@@ -3060,6 +3725,8 @@ public final class GtfsRealtimeOneBusAway {
       }
       /**
        * <code>optional string elevatorId = 1;</code>
+       * @param value The elevatorId to set.
+       * @return This builder for chaining.
        */
       public Builder setElevatorId(
           java.lang.String value) {
@@ -3073,6 +3740,7 @@ public final class GtfsRealtimeOneBusAway {
       }
       /**
        * <code>optional string elevatorId = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearElevatorId() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -3082,6 +3750,8 @@ public final class GtfsRealtimeOneBusAway {
       }
       /**
        * <code>optional string elevatorId = 1;</code>
+       * @param value The bytes for elevatorId to set.
+       * @return This builder for chaining.
        */
       public Builder setElevatorIdBytes(
           com.google.protobuf.ByteString value) {
@@ -3093,16 +3763,57 @@ public final class GtfsRealtimeOneBusAway {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.OneBusAwayEntitySelector)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayEntitySelector)
+    private static final com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector DEFAULT_INSTANCE;
     static {
-      defaultInstance = new OneBusAwayEntitySelector(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.OneBusAwayEntitySelector)
+    public static com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<OneBusAwayEntitySelector>
+        PARSER = new com.google.protobuf.AbstractParser<OneBusAwayEntitySelector>() {
+      @java.lang.Override
+      public OneBusAwayEntitySelector parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new OneBusAwayEntitySelector(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<OneBusAwayEntitySelector> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<OneBusAwayEntitySelector> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public static final int OBA_FEED_HEADER_FIELD_NUMBER = 1000;
@@ -3162,35 +3873,35 @@ public final class GtfsRealtimeOneBusAway {
         com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayEntitySelector.getDefaultInstance());
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_OneBusAwayFeedHeader_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_OneBusAwayFeedHeader_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_OneBusAwayFeedEntity_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_OneBusAwayFeedEntity_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_OneBusAwayTripUpdate_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_OneBusAwayTripUpdate_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_OneBusAwayStopTimeUpdate_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_OneBusAwayStopTimeUpdate_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_OneBusAwayEntitySelector_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_OneBusAwayEntitySelector_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
   }
-  private static com.google.protobuf.Descriptors.FileDescriptor
+  private static  com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
     java.lang.String[] descriptorData = {
@@ -3203,7 +3914,7 @@ public final class GtfsRealtimeOneBusAway {
       "ty\022\016\n\006source\030\001 \001(\t\"m\n\024OneBusAwayTripUpda" +
       "te\022\021\n\005delay\030\001 \001(\005B\002\030\001\022\025\n\ttimestamp\030\002 \001(\004" +
       "B\002\030\001\022\024\n\014tripHeadsign\030\003 \001(\t\022\025\n\rtripDirect" +
-      "ion\030\004 \001(\t\"0\n\030OneBusAwayStopTimeUpdate\022\024\n",
+      "ion\030\004 \001(\t\"0\n\030OneBusAwayStopTimeUpdate\022\024\n" +
       "\014stopHeadsign\030\001 \001(\t\".\n\030OneBusAwayEntityS" +
       "elector\022\022\n\nelevatorId\030\001 \001(\t:^\n\017oba_feed_" +
       "header\022\034.transit_realtime.FeedHeader\030\350\007 " +
@@ -3213,7 +3924,7 @@ public final class GtfsRealtimeOneBusAway {
       "neBusAwayFeedEntity:^\n\017oba_trip_update\022\034" +
       ".transit_realtime.TripUpdate\030\350\007 \001(\0132&.tr" +
       "ansit_realtime.OneBusAwayTripUpdate:v\n\024o" +
-      "ba_stop_time_update\022+.transit_realtime.T",
+      "ba_stop_time_update\022+.transit_realtime.T" +
       "ripUpdate.StopTimeUpdate\030\350\007 \001(\0132*.transi" +
       "t_realtime.OneBusAwayStopTimeUpdate:j\n\023o" +
       "ba_entity_selector\022 .transit_realtime.En" +
@@ -3221,47 +3932,39 @@ public final class GtfsRealtimeOneBusAway {
       "neBusAwayEntitySelectorB\035\n\033com.google.tr" +
       "ansit.realtime"
     };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
+    descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.transit.realtime.GtfsRealtime.getDescriptor(),
-        }, assigner);
+        });
     internal_static_transit_realtime_OneBusAwayFeedHeader_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_transit_realtime_OneBusAwayFeedHeader_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_OneBusAwayFeedHeader_descriptor,
         new java.lang.String[] { "IncrementalIndex", "IncrementalHeartbeatInterval", });
     internal_static_transit_realtime_OneBusAwayFeedEntity_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_transit_realtime_OneBusAwayFeedEntity_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_OneBusAwayFeedEntity_descriptor,
         new java.lang.String[] { "Source", });
     internal_static_transit_realtime_OneBusAwayTripUpdate_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_transit_realtime_OneBusAwayTripUpdate_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_OneBusAwayTripUpdate_descriptor,
         new java.lang.String[] { "Delay", "Timestamp", "TripHeadsign", "TripDirection", });
     internal_static_transit_realtime_OneBusAwayStopTimeUpdate_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_transit_realtime_OneBusAwayStopTimeUpdate_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_OneBusAwayStopTimeUpdate_descriptor,
         new java.lang.String[] { "StopHeadsign", });
     internal_static_transit_realtime_OneBusAwayEntitySelector_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_transit_realtime_OneBusAwayEntitySelector_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_OneBusAwayEntitySelector_descriptor,
         new java.lang.String[] { "ElevatorId", });
     obaFeedHeader.internalInit(descriptor.getExtensions().get(0));

--- a/src/main/java/com/google/transit/realtime/GtfsRealtimeServiceStatus.java
+++ b/src/main/java/com/google/transit/realtime/GtfsRealtimeServiceStatus.java
@@ -38,82 +38,93 @@ package com.google.transit.realtime;
 public final class GtfsRealtimeServiceStatus {
   private GtfsRealtimeServiceStatus() {}
   public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
+      com.google.protobuf.ExtensionRegistryLite registry) {
     registry.add(com.google.transit.realtime.GtfsRealtimeServiceStatus.mercuryFeedHeader);
     registry.add(com.google.transit.realtime.GtfsRealtimeServiceStatus.mercuryAlert);
     registry.add(com.google.transit.realtime.GtfsRealtimeServiceStatus.mercuryEntitySelector);
+  }
+
+  public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions(
+        (com.google.protobuf.ExtensionRegistryLite) registry);
   }
   public interface MercuryFeedHeaderOrBuilder extends
       // @@protoc_insertion_point(interface_extends:transit_realtime.MercuryFeedHeader)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>required string mercury_version = 1;</code>
-     *
      * <pre>
      * Version of the Mercury extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string mercury_version = 1;</code>
+     * @return Whether the mercuryVersion field is set.
      */
     boolean hasMercuryVersion();
     /**
-     * <code>required string mercury_version = 1;</code>
-     *
      * <pre>
      * Version of the Mercury extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string mercury_version = 1;</code>
+     * @return The mercuryVersion.
      */
     java.lang.String getMercuryVersion();
     /**
-     * <code>required string mercury_version = 1;</code>
-     *
      * <pre>
      * Version of the Mercury extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string mercury_version = 1;</code>
+     * @return The bytes for mercuryVersion.
      */
     com.google.protobuf.ByteString
         getMercuryVersionBytes();
   }
   /**
-   * Protobuf type {@code transit_realtime.MercuryFeedHeader}
-   *
    * <pre>
    * Mercury extensions for the Feed Header
    * </pre>
+   *
+   * Protobuf type {@code transit_realtime.MercuryFeedHeader}
    */
-  public static final class MercuryFeedHeader extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class MercuryFeedHeader extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.MercuryFeedHeader)
       MercuryFeedHeaderOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use MercuryFeedHeader.newBuilder() to construct.
-    private MercuryFeedHeader(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private MercuryFeedHeader(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private MercuryFeedHeader(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final MercuryFeedHeader defaultInstance;
-    public static MercuryFeedHeader getDefaultInstance() {
-      return defaultInstance;
+    private MercuryFeedHeader() {
+      mercuryVersion_ = "";
     }
 
-    public MercuryFeedHeader getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new MercuryFeedHeader();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private MercuryFeedHeader(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -125,17 +136,17 @@ public final class GtfsRealtimeServiceStatus {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
               mercuryVersion_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
               break;
             }
           }
@@ -144,7 +155,7 @@ public final class GtfsRealtimeServiceStatus {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -155,49 +166,37 @@ public final class GtfsRealtimeServiceStatus {
       return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryFeedHeader_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryFeedHeader_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader.class, com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader.Builder.class);
     }
 
-    public static com.google.protobuf.Parser<MercuryFeedHeader> PARSER =
-        new com.google.protobuf.AbstractParser<MercuryFeedHeader>() {
-      public MercuryFeedHeader parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MercuryFeedHeader(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<MercuryFeedHeader> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int MERCURY_VERSION_FIELD_NUMBER = 1;
-    private java.lang.Object mercuryVersion_;
+    private volatile java.lang.Object mercuryVersion_;
     /**
-     * <code>required string mercury_version = 1;</code>
-     *
      * <pre>
      * Version of the Mercury extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string mercury_version = 1;</code>
+     * @return Whether the mercuryVersion field is set.
      */
     public boolean hasMercuryVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>required string mercury_version = 1;</code>
-     *
      * <pre>
      * Version of the Mercury extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string mercury_version = 1;</code>
+     * @return The mercuryVersion.
      */
     public java.lang.String getMercuryVersion() {
       java.lang.Object ref = mercuryVersion_;
@@ -214,12 +213,13 @@ public final class GtfsRealtimeServiceStatus {
       }
     }
     /**
-     * <code>required string mercury_version = 1;</code>
-     *
      * <pre>
      * Version of the Mercury extensions
      * The current version is 1.0
      * </pre>
+     *
+     * <code>required string mercury_version = 1;</code>
+     * @return The bytes for mercuryVersion.
      */
     public com.google.protobuf.ByteString
         getMercuryVersionBytes() {
@@ -235,10 +235,8 @@ public final class GtfsRealtimeServiceStatus {
       }
     }
 
-    private void initFields() {
-      mercuryVersion_ = "";
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -252,37 +250,75 @@ public final class GtfsRealtimeServiceStatus {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getMercuryVersionBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, mercuryVersion_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getMercuryVersionBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, mercuryVersion_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader other = (com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader) obj;
+
+      if (hasMercuryVersion() != other.hasMercuryVersion()) return false;
+      if (hasMercuryVersion()) {
+        if (!getMercuryVersion()
+            .equals(other.getMercuryVersion())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasMercuryVersion()) {
+        hash = (37 * hash) + MERCURY_VERSION_FIELD_NUMBER;
+        hash = (53 * hash) + getMercuryVersion().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -306,58 +342,71 @@ public final class GtfsRealtimeServiceStatus {
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /**
-     * Protobuf type {@code transit_realtime.MercuryFeedHeader}
-     *
      * <pre>
      * Mercury extensions for the Feed Header
      * </pre>
+     *
+     * Protobuf type {@code transit_realtime.MercuryFeedHeader}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.MercuryFeedHeader)
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeaderOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -365,7 +414,8 @@ public final class GtfsRealtimeServiceStatus {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryFeedHeader_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryFeedHeader_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -378,18 +428,16 @@ public final class GtfsRealtimeServiceStatus {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         mercuryVersion_ = "";
@@ -397,19 +445,18 @@ public final class GtfsRealtimeServiceStatus {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryFeedHeader_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader build() {
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader result = buildPartial();
         if (!result.isInitialized()) {
@@ -418,11 +465,12 @@ public final class GtfsRealtimeServiceStatus {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader buildPartial() {
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader result = new com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.mercuryVersion_ = mercuryVersion_;
@@ -431,6 +479,39 @@ public final class GtfsRealtimeServiceStatus {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader)other);
@@ -447,18 +528,20 @@ public final class GtfsRealtimeServiceStatus {
           mercuryVersion_ = other.mercuryVersion_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasMercuryVersion()) {
-          
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -468,7 +551,7 @@ public final class GtfsRealtimeServiceStatus {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -480,23 +563,25 @@ public final class GtfsRealtimeServiceStatus {
 
       private java.lang.Object mercuryVersion_ = "";
       /**
-       * <code>required string mercury_version = 1;</code>
-       *
        * <pre>
        * Version of the Mercury extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string mercury_version = 1;</code>
+       * @return Whether the mercuryVersion field is set.
        */
       public boolean hasMercuryVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>required string mercury_version = 1;</code>
-       *
        * <pre>
        * Version of the Mercury extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string mercury_version = 1;</code>
+       * @return The mercuryVersion.
        */
       public java.lang.String getMercuryVersion() {
         java.lang.Object ref = mercuryVersion_;
@@ -513,12 +598,13 @@ public final class GtfsRealtimeServiceStatus {
         }
       }
       /**
-       * <code>required string mercury_version = 1;</code>
-       *
        * <pre>
        * Version of the Mercury extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string mercury_version = 1;</code>
+       * @return The bytes for mercuryVersion.
        */
       public com.google.protobuf.ByteString
           getMercuryVersionBytes() {
@@ -534,12 +620,14 @@ public final class GtfsRealtimeServiceStatus {
         }
       }
       /**
-       * <code>required string mercury_version = 1;</code>
-       *
        * <pre>
        * Version of the Mercury extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string mercury_version = 1;</code>
+       * @param value The mercuryVersion to set.
+       * @return This builder for chaining.
        */
       public Builder setMercuryVersion(
           java.lang.String value) {
@@ -552,12 +640,13 @@ public final class GtfsRealtimeServiceStatus {
         return this;
       }
       /**
-       * <code>required string mercury_version = 1;</code>
-       *
        * <pre>
        * Version of the Mercury extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string mercury_version = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearMercuryVersion() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -566,12 +655,14 @@ public final class GtfsRealtimeServiceStatus {
         return this;
       }
       /**
-       * <code>required string mercury_version = 1;</code>
-       *
        * <pre>
        * Version of the Mercury extensions
        * The current version is 1.0
        * </pre>
+       *
+       * <code>required string mercury_version = 1;</code>
+       * @param value The bytes for mercuryVersion to set.
+       * @return This builder for chaining.
        */
       public Builder setMercuryVersionBytes(
           com.google.protobuf.ByteString value) {
@@ -583,16 +674,57 @@ public final class GtfsRealtimeServiceStatus {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.MercuryFeedHeader)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.MercuryFeedHeader)
+    private static final com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader DEFAULT_INSTANCE;
     static {
-      defaultInstance = new MercuryFeedHeader(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.MercuryFeedHeader)
+    public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<MercuryFeedHeader>
+        PARSER = new com.google.protobuf.AbstractParser<MercuryFeedHeader>() {
+      @java.lang.Override
+      public MercuryFeedHeader parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MercuryFeedHeader(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MercuryFeedHeader> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MercuryFeedHeader> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryFeedHeader getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface MercuryAlertOrBuilder extends
@@ -601,74 +733,83 @@ public final class GtfsRealtimeServiceStatus {
 
     /**
      * <code>required uint64 created_at = 1;</code>
+     * @return Whether the createdAt field is set.
      */
     boolean hasCreatedAt();
     /**
      * <code>required uint64 created_at = 1;</code>
+     * @return The createdAt.
      */
     long getCreatedAt();
 
     /**
      * <code>required uint64 updated_at = 2;</code>
+     * @return Whether the updatedAt field is set.
      */
     boolean hasUpdatedAt();
     /**
      * <code>required uint64 updated_at = 2;</code>
+     * @return The updatedAt.
      */
     long getUpdatedAt();
 
     /**
      * <code>required string alert_type = 3;</code>
+     * @return Whether the alertType field is set.
      */
     boolean hasAlertType();
     /**
      * <code>required string alert_type = 3;</code>
+     * @return The alertType.
      */
     java.lang.String getAlertType();
     /**
      * <code>required string alert_type = 3;</code>
+     * @return The bytes for alertType.
      */
     com.google.protobuf.ByteString
         getAlertTypeBytes();
   }
   /**
-   * Protobuf type {@code transit_realtime.MercuryAlert}
-   *
    * <pre>
    * Mercury extensions for the Feed Alert
    * </pre>
+   *
+   * Protobuf type {@code transit_realtime.MercuryAlert}
    */
-  public static final class MercuryAlert extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class MercuryAlert extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.MercuryAlert)
       MercuryAlertOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use MercuryAlert.newBuilder() to construct.
-    private MercuryAlert(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private MercuryAlert(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private MercuryAlert(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final MercuryAlert defaultInstance;
-    public static MercuryAlert getDefaultInstance() {
-      return defaultInstance;
+    private MercuryAlert() {
+      alertType_ = "";
     }
 
-    public MercuryAlert getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new MercuryAlert();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private MercuryAlert(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -680,13 +821,6 @@ public final class GtfsRealtimeServiceStatus {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 8: {
               bitField0_ |= 0x00000001;
               createdAt_ = input.readUInt64();
@@ -703,13 +837,20 @@ public final class GtfsRealtimeServiceStatus {
               alertType_ = bs;
               break;
             }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -720,26 +861,12 @@ public final class GtfsRealtimeServiceStatus {
       return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryAlert_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryAlert_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert.class, com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<MercuryAlert> PARSER =
-        new com.google.protobuf.AbstractParser<MercuryAlert>() {
-      public MercuryAlert parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MercuryAlert(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<MercuryAlert> getParserForType() {
-      return PARSER;
     }
 
     private int bitField0_;
@@ -747,12 +874,14 @@ public final class GtfsRealtimeServiceStatus {
     private long createdAt_;
     /**
      * <code>required uint64 created_at = 1;</code>
+     * @return Whether the createdAt field is set.
      */
     public boolean hasCreatedAt() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required uint64 created_at = 1;</code>
+     * @return The createdAt.
      */
     public long getCreatedAt() {
       return createdAt_;
@@ -762,27 +891,31 @@ public final class GtfsRealtimeServiceStatus {
     private long updatedAt_;
     /**
      * <code>required uint64 updated_at = 2;</code>
+     * @return Whether the updatedAt field is set.
      */
     public boolean hasUpdatedAt() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required uint64 updated_at = 2;</code>
+     * @return The updatedAt.
      */
     public long getUpdatedAt() {
       return updatedAt_;
     }
 
     public static final int ALERT_TYPE_FIELD_NUMBER = 3;
-    private java.lang.Object alertType_;
+    private volatile java.lang.Object alertType_;
     /**
      * <code>required string alert_type = 3;</code>
+     * @return Whether the alertType field is set.
      */
     public boolean hasAlertType() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required string alert_type = 3;</code>
+     * @return The alertType.
      */
     public java.lang.String getAlertType() {
       java.lang.Object ref = alertType_;
@@ -800,6 +933,7 @@ public final class GtfsRealtimeServiceStatus {
     }
     /**
      * <code>required string alert_type = 3;</code>
+     * @return The bytes for alertType.
      */
     public com.google.protobuf.ByteString
         getAlertTypeBytes() {
@@ -815,12 +949,8 @@ public final class GtfsRealtimeServiceStatus {
       }
     }
 
-    private void initFields() {
-      createdAt_ = 0L;
-      updatedAt_ = 0L;
-      alertType_ = "";
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -842,51 +972,109 @@ public final class GtfsRealtimeServiceStatus {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeUInt64(1, createdAt_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeUInt64(2, updatedAt_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeBytes(3, getAlertTypeBytes());
+      if (((bitField0_ & 0x00000004) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, alertType_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(1, createdAt_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, updatedAt_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(3, getAlertTypeBytes());
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, alertType_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert other = (com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert) obj;
+
+      if (hasCreatedAt() != other.hasCreatedAt()) return false;
+      if (hasCreatedAt()) {
+        if (getCreatedAt()
+            != other.getCreatedAt()) return false;
+      }
+      if (hasUpdatedAt() != other.hasUpdatedAt()) return false;
+      if (hasUpdatedAt()) {
+        if (getUpdatedAt()
+            != other.getUpdatedAt()) return false;
+      }
+      if (hasAlertType() != other.hasAlertType()) return false;
+      if (hasAlertType()) {
+        if (!getAlertType()
+            .equals(other.getAlertType())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasCreatedAt()) {
+        hash = (37 * hash) + CREATED_AT_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getCreatedAt());
+      }
+      if (hasUpdatedAt()) {
+        hash = (37 * hash) + UPDATED_AT_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getUpdatedAt());
+      }
+      if (hasAlertType()) {
+        hash = (37 * hash) + ALERT_TYPE_FIELD_NUMBER;
+        hash = (53 * hash) + getAlertType().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -910,58 +1098,71 @@ public final class GtfsRealtimeServiceStatus {
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /**
-     * Protobuf type {@code transit_realtime.MercuryAlert}
-     *
      * <pre>
      * Mercury extensions for the Feed Alert
      * </pre>
+     *
+     * Protobuf type {@code transit_realtime.MercuryAlert}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.MercuryAlert)
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlertOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -969,7 +1170,8 @@ public final class GtfsRealtimeServiceStatus {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryAlert_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryAlert_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -982,18 +1184,16 @@ public final class GtfsRealtimeServiceStatus {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         createdAt_ = 0L;
@@ -1005,19 +1205,18 @@ public final class GtfsRealtimeServiceStatus {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryAlert_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert build() {
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert result = buildPartial();
         if (!result.isInitialized()) {
@@ -1026,19 +1225,20 @@ public final class GtfsRealtimeServiceStatus {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert buildPartial() {
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert result = new com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.createdAt_ = createdAt_;
           to_bitField0_ |= 0x00000001;
         }
-        result.createdAt_ = createdAt_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.updatedAt_ = updatedAt_;
           to_bitField0_ |= 0x00000002;
         }
-        result.updatedAt_ = updatedAt_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.alertType_ = alertType_;
@@ -1047,6 +1247,39 @@ public final class GtfsRealtimeServiceStatus {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert)other);
@@ -1069,26 +1302,26 @@ public final class GtfsRealtimeServiceStatus {
           alertType_ = other.alertType_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasCreatedAt()) {
-          
           return false;
         }
         if (!hasUpdatedAt()) {
-          
           return false;
         }
         if (!hasAlertType()) {
-          
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1098,7 +1331,7 @@ public final class GtfsRealtimeServiceStatus {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1111,18 +1344,22 @@ public final class GtfsRealtimeServiceStatus {
       private long createdAt_ ;
       /**
        * <code>required uint64 created_at = 1;</code>
+       * @return Whether the createdAt field is set.
        */
       public boolean hasCreatedAt() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required uint64 created_at = 1;</code>
+       * @return The createdAt.
        */
       public long getCreatedAt() {
         return createdAt_;
       }
       /**
        * <code>required uint64 created_at = 1;</code>
+       * @param value The createdAt to set.
+       * @return This builder for chaining.
        */
       public Builder setCreatedAt(long value) {
         bitField0_ |= 0x00000001;
@@ -1132,6 +1369,7 @@ public final class GtfsRealtimeServiceStatus {
       }
       /**
        * <code>required uint64 created_at = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearCreatedAt() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -1143,18 +1381,22 @@ public final class GtfsRealtimeServiceStatus {
       private long updatedAt_ ;
       /**
        * <code>required uint64 updated_at = 2;</code>
+       * @return Whether the updatedAt field is set.
        */
       public boolean hasUpdatedAt() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required uint64 updated_at = 2;</code>
+       * @return The updatedAt.
        */
       public long getUpdatedAt() {
         return updatedAt_;
       }
       /**
        * <code>required uint64 updated_at = 2;</code>
+       * @param value The updatedAt to set.
+       * @return This builder for chaining.
        */
       public Builder setUpdatedAt(long value) {
         bitField0_ |= 0x00000002;
@@ -1164,6 +1406,7 @@ public final class GtfsRealtimeServiceStatus {
       }
       /**
        * <code>required uint64 updated_at = 2;</code>
+       * @return This builder for chaining.
        */
       public Builder clearUpdatedAt() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -1175,12 +1418,14 @@ public final class GtfsRealtimeServiceStatus {
       private java.lang.Object alertType_ = "";
       /**
        * <code>required string alert_type = 3;</code>
+       * @return Whether the alertType field is set.
        */
       public boolean hasAlertType() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required string alert_type = 3;</code>
+       * @return The alertType.
        */
       public java.lang.String getAlertType() {
         java.lang.Object ref = alertType_;
@@ -1198,6 +1443,7 @@ public final class GtfsRealtimeServiceStatus {
       }
       /**
        * <code>required string alert_type = 3;</code>
+       * @return The bytes for alertType.
        */
       public com.google.protobuf.ByteString
           getAlertTypeBytes() {
@@ -1214,6 +1460,8 @@ public final class GtfsRealtimeServiceStatus {
       }
       /**
        * <code>required string alert_type = 3;</code>
+       * @param value The alertType to set.
+       * @return This builder for chaining.
        */
       public Builder setAlertType(
           java.lang.String value) {
@@ -1227,6 +1475,7 @@ public final class GtfsRealtimeServiceStatus {
       }
       /**
        * <code>required string alert_type = 3;</code>
+       * @return This builder for chaining.
        */
       public Builder clearAlertType() {
         bitField0_ = (bitField0_ & ~0x00000004);
@@ -1236,6 +1485,8 @@ public final class GtfsRealtimeServiceStatus {
       }
       /**
        * <code>required string alert_type = 3;</code>
+       * @param value The bytes for alertType to set.
+       * @return This builder for chaining.
        */
       public Builder setAlertTypeBytes(
           com.google.protobuf.ByteString value) {
@@ -1247,16 +1498,57 @@ public final class GtfsRealtimeServiceStatus {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.MercuryAlert)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.MercuryAlert)
+    private static final com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert DEFAULT_INSTANCE;
     static {
-      defaultInstance = new MercuryAlert(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.MercuryAlert)
+    public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<MercuryAlert>
+        PARSER = new com.google.protobuf.AbstractParser<MercuryAlert>() {
+      @java.lang.Override
+      public MercuryAlert parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MercuryAlert(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MercuryAlert> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MercuryAlert> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryAlert getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public interface MercuryEntitySelectorOrBuilder extends
@@ -1264,69 +1556,74 @@ public final class GtfsRealtimeServiceStatus {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>required string sort_order = 1;</code>
-     *
      * <pre>
      * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
      * </pre>
+     *
+     * <code>required string sort_order = 1;</code>
+     * @return Whether the sortOrder field is set.
      */
     boolean hasSortOrder();
     /**
-     * <code>required string sort_order = 1;</code>
-     *
      * <pre>
      * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
      * </pre>
+     *
+     * <code>required string sort_order = 1;</code>
+     * @return The sortOrder.
      */
     java.lang.String getSortOrder();
     /**
-     * <code>required string sort_order = 1;</code>
-     *
      * <pre>
      * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
      * </pre>
+     *
+     * <code>required string sort_order = 1;</code>
+     * @return The bytes for sortOrder.
      */
     com.google.protobuf.ByteString
         getSortOrderBytes();
   }
   /**
-   * Protobuf type {@code transit_realtime.MercuryEntitySelector}
-   *
    * <pre>
    * Mercury extensions for the Feed Entity Selector
    * </pre>
+   *
+   * Protobuf type {@code transit_realtime.MercuryEntitySelector}
    */
-  public static final class MercuryEntitySelector extends
-      com.google.protobuf.GeneratedMessage implements
+  public  static final class MercuryEntitySelector extends
+      com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:transit_realtime.MercuryEntitySelector)
       MercuryEntitySelectorOrBuilder {
+  private static final long serialVersionUID = 0L;
     // Use MercuryEntitySelector.newBuilder() to construct.
-    private MercuryEntitySelector(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+    private MercuryEntitySelector(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
-    private MercuryEntitySelector(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final MercuryEntitySelector defaultInstance;
-    public static MercuryEntitySelector getDefaultInstance() {
-      return defaultInstance;
+    private MercuryEntitySelector() {
+      sortOrder_ = "";
     }
 
-    public MercuryEntitySelector getDefaultInstanceForType() {
-      return defaultInstance;
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new MercuryEntitySelector();
     }
 
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
     @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
+    getUnknownFields() {
       return this.unknownFields;
     }
     private MercuryEntitySelector(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1338,17 +1635,17 @@ public final class GtfsRealtimeServiceStatus {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
               sortOrder_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
               break;
             }
           }
@@ -1357,7 +1654,7 @@ public final class GtfsRealtimeServiceStatus {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
         throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
+            e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -1368,26 +1665,12 @@ public final class GtfsRealtimeServiceStatus {
       return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryEntitySelector_descriptor;
     }
 
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryEntitySelector_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector.class, com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<MercuryEntitySelector> PARSER =
-        new com.google.protobuf.AbstractParser<MercuryEntitySelector>() {
-      public MercuryEntitySelector parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MercuryEntitySelector(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<MercuryEntitySelector> getParserForType() {
-      return PARSER;
     }
 
     /**
@@ -1398,87 +1681,87 @@ public final class GtfsRealtimeServiceStatus {
       /**
        * <code>PRIORITY_NO_SCHEDULED_SERVICE = 1;</code>
        */
-      PRIORITY_NO_SCHEDULED_SERVICE(0, 1),
+      PRIORITY_NO_SCHEDULED_SERVICE(1),
       /**
        * <code>PRIORITY_SUNDAY_SCHEDULE = 2;</code>
        */
-      PRIORITY_SUNDAY_SCHEDULE(1, 2),
+      PRIORITY_SUNDAY_SCHEDULE(2),
       /**
        * <code>PRIORITY_SATURDAY_SCHEDULE = 3;</code>
        */
-      PRIORITY_SATURDAY_SCHEDULE(2, 3),
+      PRIORITY_SATURDAY_SCHEDULE(3),
       /**
        * <code>PRIORITY_HOLIDAY_SERVICE = 4;</code>
        */
-      PRIORITY_HOLIDAY_SERVICE(3, 4),
+      PRIORITY_HOLIDAY_SERVICE(4),
       /**
        * <code>PRIORITY_EXTRA_SERVICE = 5;</code>
        */
-      PRIORITY_EXTRA_SERVICE(4, 5),
+      PRIORITY_EXTRA_SERVICE(5),
       /**
        * <code>PRIORITY_PLANNED_WORK = 6;</code>
        */
-      PRIORITY_PLANNED_WORK(5, 6),
+      PRIORITY_PLANNED_WORK(6),
       /**
        * <code>PRIORITY_ON_OR_CLOSE = 7;</code>
        */
-      PRIORITY_ON_OR_CLOSE(6, 7),
+      PRIORITY_ON_OR_CLOSE(7),
       /**
        * <code>PRIORITY_SLOW_SPEEDS = 8;</code>
        */
-      PRIORITY_SLOW_SPEEDS(7, 8),
+      PRIORITY_SLOW_SPEEDS(8),
       /**
        * <code>PRIORITY_SOME_DELAYS = 9;</code>
        */
-      PRIORITY_SOME_DELAYS(8, 9),
+      PRIORITY_SOME_DELAYS(9),
       /**
        * <code>PRIORITY_SPECIAL_EVENT = 10;</code>
        */
-      PRIORITY_SPECIAL_EVENT(9, 10),
+      PRIORITY_SPECIAL_EVENT(10),
       /**
        * <code>PRIORITY_STATIONS_SKIPPED = 11;</code>
        */
-      PRIORITY_STATIONS_SKIPPED(10, 11),
+      PRIORITY_STATIONS_SKIPPED(11),
       /**
        * <code>PRIORITY_DELAYS = 12;</code>
        */
-      PRIORITY_DELAYS(11, 12),
+      PRIORITY_DELAYS(12),
       /**
        * <code>PRIORITY_EXPRESS_TO_LOCAL = 13;</code>
        */
-      PRIORITY_EXPRESS_TO_LOCAL(12, 13),
+      PRIORITY_EXPRESS_TO_LOCAL(13),
       /**
        * <code>PRIORITY_SOME_REROUTES = 14;</code>
        */
-      PRIORITY_SOME_REROUTES(13, 14),
+      PRIORITY_SOME_REROUTES(14),
       /**
        * <code>PRIORITY_LOCAL_TO_EXPRESS = 15;</code>
        */
-      PRIORITY_LOCAL_TO_EXPRESS(14, 15),
+      PRIORITY_LOCAL_TO_EXPRESS(15),
       /**
        * <code>PRIORITY_SERVICE_CHANGE = 16;</code>
        */
-      PRIORITY_SERVICE_CHANGE(15, 16),
+      PRIORITY_SERVICE_CHANGE(16),
       /**
        * <code>PRIORITY_TRAINS_REROUTED = 17;</code>
        */
-      PRIORITY_TRAINS_REROUTED(16, 17),
+      PRIORITY_TRAINS_REROUTED(17),
       /**
        * <code>PRIORITY_PART_SUSPENDED = 18;</code>
        */
-      PRIORITY_PART_SUSPENDED(17, 18),
+      PRIORITY_PART_SUSPENDED(18),
       /**
        * <code>PRIORITY_MULTIPLE_IMPACTS = 19;</code>
        */
-      PRIORITY_MULTIPLE_IMPACTS(18, 19),
+      PRIORITY_MULTIPLE_IMPACTS(19),
       /**
        * <code>PRIORITY_SUSPENDED = 20;</code>
        */
-      PRIORITY_SUSPENDED(19, 20),
+      PRIORITY_SUSPENDED(20),
       /**
        * <code>PRIORITY_BUSING = 21;</code>
        */
-      PRIORITY_BUSING(20, 21),
+      PRIORITY_BUSING(21),
       ;
 
       /**
@@ -1567,9 +1850,25 @@ public final class GtfsRealtimeServiceStatus {
       public static final int PRIORITY_BUSING_VALUE = 21;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static Priority valueOf(int value) {
+        return forNumber(value);
+      }
+
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       */
+      public static Priority forNumber(int value) {
         switch (value) {
           case 1: return PRIORITY_NO_SCHEDULED_SERVICE;
           case 2: return PRIORITY_SUNDAY_SCHEDULE;
@@ -1600,17 +1899,17 @@ public final class GtfsRealtimeServiceStatus {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<Priority>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          Priority> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<Priority>() {
               public Priority findValueByNumber(int number) {
-                return Priority.valueOf(number);
+                return Priority.forNumber(number);
               }
             };
 
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
+        return getDescriptor().getValues().get(ordinal());
       }
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
@@ -1632,11 +1931,9 @@ public final class GtfsRealtimeServiceStatus {
         return VALUES[desc.getIndex()];
       }
 
-      private final int index;
       private final int value;
 
-      private Priority(int index, int value) {
-        this.index = index;
+      private Priority(int value) {
         this.value = value;
       }
 
@@ -1651,91 +1948,51 @@ public final class GtfsRealtimeServiceStatus {
       /**
        * <code>NYCT_BUS_PRIORITY_NO_SCHEDULED_SERVICE = 1;</code>
        */
-      NYCT_BUS_PRIORITY_NO_SCHEDULED_SERVICE(0, 1),
+      NYCT_BUS_PRIORITY_NO_SCHEDULED_SERVICE(1),
       /**
        * <code>NYCT_BUS_PRIORITY_SUNDAY_SCHEDULE = 2;</code>
        */
-      NYCT_BUS_PRIORITY_SUNDAY_SCHEDULE(1, 2),
+      NYCT_BUS_PRIORITY_SUNDAY_SCHEDULE(2),
       /**
        * <code>NYCT_BUS_PRIORITY_SATURDAY_SCHEDULE = 3;</code>
        */
-      NYCT_BUS_PRIORITY_SATURDAY_SCHEDULE(2, 3),
+      NYCT_BUS_PRIORITY_SATURDAY_SCHEDULE(3),
       /**
        * <code>NYCT_BUS_PRIORITY_HOLIDAY_SERVICE = 4;</code>
        */
-      NYCT_BUS_PRIORITY_HOLIDAY_SERVICE(3, 4),
+      NYCT_BUS_PRIORITY_HOLIDAY_SERVICE(4),
       /**
        * <code>NYCT_BUS_PRIORITY_PLANNED_DETOUR = 5;</code>
        */
-      NYCT_BUS_PRIORITY_PLANNED_DETOUR(4, 5),
+      NYCT_BUS_PRIORITY_PLANNED_DETOUR(5),
       /**
        * <code>NYCT_BUS_PRIORITY_EXTRA_SERVICE = 6;</code>
        */
-      NYCT_BUS_PRIORITY_EXTRA_SERVICE(5, 6),
+      NYCT_BUS_PRIORITY_EXTRA_SERVICE(6),
       /**
        * <code>NYCT_BUS_PRIORITY_PLANNED_WORK = 7;</code>
        */
-      NYCT_BUS_PRIORITY_PLANNED_WORK(6, 7),
-      /**
-       * <code>NYCT_BUS_PRIORITY_ON_OR_CLOSE = 8;</code>
-       */
-      NYCT_BUS_PRIORITY_ON_OR_CLOSE(7, 8),
-      /**
-       * <code>NYCT_BUS_PRIORITY_SLOW_SPEEDS = 9;</code>
-       */
-      NYCT_BUS_PRIORITY_SLOW_SPEEDS(8, 9),
-      /**
-       * <code>NYCT_BUS_PRIORITY_SOME_DELAYS = 10;</code>
-       */
-      NYCT_BUS_PRIORITY_SOME_DELAYS(9, 10),
+      NYCT_BUS_PRIORITY_PLANNED_WORK(7),
       /**
        * <code>NYCT_BUS_PRIORITY_SPECIAL_EVENT = 11;</code>
        */
-      NYCT_BUS_PRIORITY_SPECIAL_EVENT(10, 11),
-      /**
-       * <code>NYCT_BUS_PRIORITY_STATIONS_SKIPPED = 12;</code>
-       */
-      NYCT_BUS_PRIORITY_STATIONS_SKIPPED(11, 12),
+      NYCT_BUS_PRIORITY_SPECIAL_EVENT(11),
       /**
        * <code>NYCT_BUS_PRIORITY_DELAYS = 13;</code>
        */
-      NYCT_BUS_PRIORITY_DELAYS(12, 13),
+      NYCT_BUS_PRIORITY_DELAYS(13),
       /**
-       * <code>NYCT_BUS_PRIORITY_EXPRESS_TO_LOCAL = 14;</code>
+       * <code>NYCT_BUS_PRIORITY_DETOURS = 16;</code>
        */
-      NYCT_BUS_PRIORITY_EXPRESS_TO_LOCAL(13, 14),
-      /**
-       * <code>NYCT_BUS_PRIORITY_SOME_REROUTES = 15;</code>
-       */
-      NYCT_BUS_PRIORITY_SOME_REROUTES(14, 15),
-      /**
-       * <code>NYCT_BUS_PRIORITY_DETOUR = 16;</code>
-       */
-      NYCT_BUS_PRIORITY_DETOUR(15, 16),
-      /**
-       * <code>NYCT_BUS_PRIORITY_LOCAL_TO_EXPRESS = 17;</code>
-       */
-      NYCT_BUS_PRIORITY_LOCAL_TO_EXPRESS(16, 17),
+      NYCT_BUS_PRIORITY_DETOURS(16),
       /**
        * <code>NYCT_BUS_PRIORITY_SERVICE_CHANGE = 18;</code>
        */
-      NYCT_BUS_PRIORITY_SERVICE_CHANGE(17, 18),
-      /**
-       * <code>NYCT_BUS_PRIORITY_TRAINS_REROUTED = 19;</code>
-       */
-      NYCT_BUS_PRIORITY_TRAINS_REROUTED(18, 19),
-      /**
-       * <code>NYCT_BUS_PRIORITY_PART_SUSPENDED = 20;</code>
-       */
-      NYCT_BUS_PRIORITY_PART_SUSPENDED(19, 20),
-      /**
-       * <code>NYCT_BUS_PRIORITY_MULTIPLE_IMPACTS = 21;</code>
-       */
-      NYCT_BUS_PRIORITY_MULTIPLE_IMPACTS(20, 21),
+      NYCT_BUS_PRIORITY_SERVICE_CHANGE(18),
       /**
        * <code>NYCT_BUS_PRIORITY_SUSPENDED = 22;</code>
        */
-      NYCT_BUS_PRIORITY_SUSPENDED(21, 22),
+      NYCT_BUS_PRIORITY_SUSPENDED(22),
       ;
 
       /**
@@ -1767,70 +2024,46 @@ public final class GtfsRealtimeServiceStatus {
        */
       public static final int NYCT_BUS_PRIORITY_PLANNED_WORK_VALUE = 7;
       /**
-       * <code>NYCT_BUS_PRIORITY_ON_OR_CLOSE = 8;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_ON_OR_CLOSE_VALUE = 8;
-      /**
-       * <code>NYCT_BUS_PRIORITY_SLOW_SPEEDS = 9;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_SLOW_SPEEDS_VALUE = 9;
-      /**
-       * <code>NYCT_BUS_PRIORITY_SOME_DELAYS = 10;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_SOME_DELAYS_VALUE = 10;
-      /**
        * <code>NYCT_BUS_PRIORITY_SPECIAL_EVENT = 11;</code>
        */
       public static final int NYCT_BUS_PRIORITY_SPECIAL_EVENT_VALUE = 11;
-      /**
-       * <code>NYCT_BUS_PRIORITY_STATIONS_SKIPPED = 12;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_STATIONS_SKIPPED_VALUE = 12;
       /**
        * <code>NYCT_BUS_PRIORITY_DELAYS = 13;</code>
        */
       public static final int NYCT_BUS_PRIORITY_DELAYS_VALUE = 13;
       /**
-       * <code>NYCT_BUS_PRIORITY_EXPRESS_TO_LOCAL = 14;</code>
+       * <code>NYCT_BUS_PRIORITY_DETOURS = 16;</code>
        */
-      public static final int NYCT_BUS_PRIORITY_EXPRESS_TO_LOCAL_VALUE = 14;
-      /**
-       * <code>NYCT_BUS_PRIORITY_SOME_REROUTES = 15;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_SOME_REROUTES_VALUE = 15;
-      /**
-       * <code>NYCT_BUS_PRIORITY_DETOUR = 16;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_DETOUR_VALUE = 16;
-      /**
-       * <code>NYCT_BUS_PRIORITY_LOCAL_TO_EXPRESS = 17;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_LOCAL_TO_EXPRESS_VALUE = 17;
+      public static final int NYCT_BUS_PRIORITY_DETOURS_VALUE = 16;
       /**
        * <code>NYCT_BUS_PRIORITY_SERVICE_CHANGE = 18;</code>
        */
       public static final int NYCT_BUS_PRIORITY_SERVICE_CHANGE_VALUE = 18;
-      /**
-       * <code>NYCT_BUS_PRIORITY_TRAINS_REROUTED = 19;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_TRAINS_REROUTED_VALUE = 19;
-      /**
-       * <code>NYCT_BUS_PRIORITY_PART_SUSPENDED = 20;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_PART_SUSPENDED_VALUE = 20;
-      /**
-       * <code>NYCT_BUS_PRIORITY_MULTIPLE_IMPACTS = 21;</code>
-       */
-      public static final int NYCT_BUS_PRIORITY_MULTIPLE_IMPACTS_VALUE = 21;
       /**
        * <code>NYCT_BUS_PRIORITY_SUSPENDED = 22;</code>
        */
       public static final int NYCT_BUS_PRIORITY_SUSPENDED_VALUE = 22;
 
 
-      public final int getNumber() { return value; }
+      public final int getNumber() {
+        return value;
+      }
 
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
       public static NyctBusPriority valueOf(int value) {
+        return forNumber(value);
+      }
+
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       */
+      public static NyctBusPriority forNumber(int value) {
         switch (value) {
           case 1: return NYCT_BUS_PRIORITY_NO_SCHEDULED_SERVICE;
           case 2: return NYCT_BUS_PRIORITY_SUNDAY_SCHEDULE;
@@ -1839,20 +2072,10 @@ public final class GtfsRealtimeServiceStatus {
           case 5: return NYCT_BUS_PRIORITY_PLANNED_DETOUR;
           case 6: return NYCT_BUS_PRIORITY_EXTRA_SERVICE;
           case 7: return NYCT_BUS_PRIORITY_PLANNED_WORK;
-          case 8: return NYCT_BUS_PRIORITY_ON_OR_CLOSE;
-          case 9: return NYCT_BUS_PRIORITY_SLOW_SPEEDS;
-          case 10: return NYCT_BUS_PRIORITY_SOME_DELAYS;
           case 11: return NYCT_BUS_PRIORITY_SPECIAL_EVENT;
-          case 12: return NYCT_BUS_PRIORITY_STATIONS_SKIPPED;
           case 13: return NYCT_BUS_PRIORITY_DELAYS;
-          case 14: return NYCT_BUS_PRIORITY_EXPRESS_TO_LOCAL;
-          case 15: return NYCT_BUS_PRIORITY_SOME_REROUTES;
-          case 16: return NYCT_BUS_PRIORITY_DETOUR;
-          case 17: return NYCT_BUS_PRIORITY_LOCAL_TO_EXPRESS;
+          case 16: return NYCT_BUS_PRIORITY_DETOURS;
           case 18: return NYCT_BUS_PRIORITY_SERVICE_CHANGE;
-          case 19: return NYCT_BUS_PRIORITY_TRAINS_REROUTED;
-          case 20: return NYCT_BUS_PRIORITY_PART_SUSPENDED;
-          case 21: return NYCT_BUS_PRIORITY_MULTIPLE_IMPACTS;
           case 22: return NYCT_BUS_PRIORITY_SUSPENDED;
           default: return null;
         }
@@ -1862,17 +2085,17 @@ public final class GtfsRealtimeServiceStatus {
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static com.google.protobuf.Internal.EnumLiteMap<NyctBusPriority>
-          internalValueMap =
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          NyctBusPriority> internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<NyctBusPriority>() {
               public NyctBusPriority findValueByNumber(int number) {
-                return NyctBusPriority.valueOf(number);
+                return NyctBusPriority.forNumber(number);
               }
             };
 
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
+        return getDescriptor().getValues().get(ordinal());
       }
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
@@ -1894,11 +2117,9 @@ public final class GtfsRealtimeServiceStatus {
         return VALUES[desc.getIndex()];
       }
 
-      private final int index;
       private final int value;
 
-      private NyctBusPriority(int index, int value) {
-        this.index = index;
+      private NyctBusPriority(int value) {
         this.value = value;
       }
 
@@ -1907,23 +2128,25 @@ public final class GtfsRealtimeServiceStatus {
 
     private int bitField0_;
     public static final int SORT_ORDER_FIELD_NUMBER = 1;
-    private java.lang.Object sortOrder_;
+    private volatile java.lang.Object sortOrder_;
     /**
-     * <code>required string sort_order = 1;</code>
-     *
      * <pre>
      * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
      * </pre>
+     *
+     * <code>required string sort_order = 1;</code>
+     * @return Whether the sortOrder field is set.
      */
     public boolean hasSortOrder() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
-     * <code>required string sort_order = 1;</code>
-     *
      * <pre>
      * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
      * </pre>
+     *
+     * <code>required string sort_order = 1;</code>
+     * @return The sortOrder.
      */
     public java.lang.String getSortOrder() {
       java.lang.Object ref = sortOrder_;
@@ -1940,11 +2163,12 @@ public final class GtfsRealtimeServiceStatus {
       }
     }
     /**
-     * <code>required string sort_order = 1;</code>
-     *
      * <pre>
      * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
      * </pre>
+     *
+     * <code>required string sort_order = 1;</code>
+     * @return The bytes for sortOrder.
      */
     public com.google.protobuf.ByteString
         getSortOrderBytes() {
@@ -1960,10 +2184,8 @@ public final class GtfsRealtimeServiceStatus {
       }
     }
 
-    private void initFields() {
-      sortOrder_ = "";
-    }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1977,37 +2199,75 @@ public final class GtfsRealtimeServiceStatus {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getSortOrderBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, sortOrder_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getSortOrderBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, sortOrder_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
     @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector)) {
+        return super.equals(obj);
+      }
+      com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector other = (com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector) obj;
+
+      if (hasSortOrder() != other.hasSortOrder()) return false;
+      if (hasSortOrder()) {
+        if (!getSortOrder()
+            .equals(other.getSortOrder())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasSortOrder()) {
+        hash = (37 * hash) + SORT_ORDER_FIELD_NUMBER;
+        hash = (53 * hash) + getSortOrder().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2031,58 +2291,71 @@ public final class GtfsRealtimeServiceStatus {
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
     }
     public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
-    public Builder toBuilder() { return newBuilder(this); }
+    public static Builder newBuilder(com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /**
-     * Protobuf type {@code transit_realtime.MercuryEntitySelector}
-     *
      * <pre>
      * Mercury extensions for the Feed Entity Selector
      * </pre>
+     *
+     * Protobuf type {@code transit_realtime.MercuryEntitySelector}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:transit_realtime.MercuryEntitySelector)
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelectorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -2090,7 +2363,8 @@ public final class GtfsRealtimeServiceStatus {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryEntitySelector_descriptor;
       }
 
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryEntitySelector_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2103,18 +2377,16 @@ public final class GtfsRealtimeServiceStatus {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
         }
       }
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         sortOrder_ = "";
@@ -2122,19 +2394,18 @@ public final class GtfsRealtimeServiceStatus {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.internal_static_transit_realtime_MercuryEntitySelector_descriptor;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector getDefaultInstanceForType() {
         return com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector build() {
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector result = buildPartial();
         if (!result.isInitialized()) {
@@ -2143,11 +2414,12 @@ public final class GtfsRealtimeServiceStatus {
         return result;
       }
 
+      @java.lang.Override
       public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector buildPartial() {
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector result = new com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.sortOrder_ = sortOrder_;
@@ -2156,6 +2428,39 @@ public final class GtfsRealtimeServiceStatus {
         return result;
       }
 
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector) {
           return mergeFrom((com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector)other);
@@ -2172,18 +2477,20 @@ public final class GtfsRealtimeServiceStatus {
           sortOrder_ = other.sortOrder_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasSortOrder()) {
-          
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2193,7 +2500,7 @@ public final class GtfsRealtimeServiceStatus {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
           parsedMessage = (com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector) e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -2205,21 +2512,23 @@ public final class GtfsRealtimeServiceStatus {
 
       private java.lang.Object sortOrder_ = "";
       /**
-       * <code>required string sort_order = 1;</code>
-       *
        * <pre>
        * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
        * </pre>
+       *
+       * <code>required string sort_order = 1;</code>
+       * @return Whether the sortOrder field is set.
        */
       public boolean hasSortOrder() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
-       * <code>required string sort_order = 1;</code>
-       *
        * <pre>
        * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
        * </pre>
+       *
+       * <code>required string sort_order = 1;</code>
+       * @return The sortOrder.
        */
       public java.lang.String getSortOrder() {
         java.lang.Object ref = sortOrder_;
@@ -2236,11 +2545,12 @@ public final class GtfsRealtimeServiceStatus {
         }
       }
       /**
-       * <code>required string sort_order = 1;</code>
-       *
        * <pre>
        * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
        * </pre>
+       *
+       * <code>required string sort_order = 1;</code>
+       * @return The bytes for sortOrder.
        */
       public com.google.protobuf.ByteString
           getSortOrderBytes() {
@@ -2256,11 +2566,13 @@ public final class GtfsRealtimeServiceStatus {
         }
       }
       /**
-       * <code>required string sort_order = 1;</code>
-       *
        * <pre>
        * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
        * </pre>
+       *
+       * <code>required string sort_order = 1;</code>
+       * @param value The sortOrder to set.
+       * @return This builder for chaining.
        */
       public Builder setSortOrder(
           java.lang.String value) {
@@ -2273,11 +2585,12 @@ public final class GtfsRealtimeServiceStatus {
         return this;
       }
       /**
-       * <code>required string sort_order = 1;</code>
-       *
        * <pre>
        * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
        * </pre>
+       *
+       * <code>required string sort_order = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearSortOrder() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -2286,11 +2599,13 @@ public final class GtfsRealtimeServiceStatus {
         return this;
       }
       /**
-       * <code>required string sort_order = 1;</code>
-       *
        * <pre>
        * Format for sort_order is 'GTFS-ID:Priority', e.g. 'MTASBWY:G:16'
        * </pre>
+       *
+       * <code>required string sort_order = 1;</code>
+       * @param value The bytes for sortOrder to set.
+       * @return This builder for chaining.
        */
       public Builder setSortOrderBytes(
           com.google.protobuf.ByteString value) {
@@ -2302,16 +2617,57 @@ public final class GtfsRealtimeServiceStatus {
         onChanged();
         return this;
       }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
 
       // @@protoc_insertion_point(builder_scope:transit_realtime.MercuryEntitySelector)
     }
 
+    // @@protoc_insertion_point(class_scope:transit_realtime.MercuryEntitySelector)
+    private static final com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector DEFAULT_INSTANCE;
     static {
-      defaultInstance = new MercuryEntitySelector(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE = new com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector();
     }
 
-    // @@protoc_insertion_point(class_scope:transit_realtime.MercuryEntitySelector)
+    public static com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<MercuryEntitySelector>
+        PARSER = new com.google.protobuf.AbstractParser<MercuryEntitySelector>() {
+      @java.lang.Override
+      public MercuryEntitySelector parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MercuryEntitySelector(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MercuryEntitySelector> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MercuryEntitySelector> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
   }
 
   public static final int MERCURY_FEED_HEADER_FIELD_NUMBER = 1001;
@@ -2349,25 +2705,25 @@ public final class GtfsRealtimeServiceStatus {
         com.google.transit.realtime.GtfsRealtimeServiceStatus.MercuryEntitySelector.getDefaultInstance());
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_MercuryFeedHeader_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_MercuryFeedHeader_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_MercuryAlert_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_MercuryAlert_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_transit_realtime_MercuryEntitySelector_descriptor;
-  private static
-    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_transit_realtime_MercuryEntitySelector_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
     return descriptor;
   }
-  private static com.google.protobuf.Descriptors.FileDescriptor
+  private static  com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
     java.lang.String[] descriptorData = {
@@ -2377,10 +2733,10 @@ public final class GtfsRealtimeServiceStatus {
       "ltime.proto\",\n\021MercuryFeedHeader\022\027\n\017merc" +
       "ury_version\030\001 \002(\t\"J\n\014MercuryAlert\022\022\n\ncre" +
       "ated_at\030\001 \002(\004\022\022\n\nupdated_at\030\002 \002(\004\022\022\n\nale" +
-      "rt_type\030\003 \002(\t\"\323\013\n\025MercuryEntitySelector\022" +
+      "rt_type\030\003 \002(\t\"\331\010\n\025MercuryEntitySelector\022" +
       "\022\n\nsort_order\030\001 \002(\t\"\334\004\n\010Priority\022!\n\035PRIO" +
       "RITY_NO_SCHEDULED_SERVICE\020\001\022\034\n\030PRIORITY_" +
-      "SUNDAY_SCHEDULE\020\002\022\036\n\032PRIORITY_SATURDAY_S",
+      "SUNDAY_SCHEDULE\020\002\022\036\n\032PRIORITY_SATURDAY_S" +
       "CHEDULE\020\003\022\034\n\030PRIORITY_HOLIDAY_SERVICE\020\004\022" +
       "\032\n\026PRIORITY_EXTRA_SERVICE\020\005\022\031\n\025PRIORITY_" +
       "PLANNED_WORK\020\006\022\030\n\024PRIORITY_ON_OR_CLOSE\020\007" +
@@ -2390,69 +2746,52 @@ public final class GtfsRealtimeServiceStatus {
       "ITY_DELAYS\020\014\022\035\n\031PRIORITY_EXPRESS_TO_LOCA" +
       "L\020\r\022\032\n\026PRIORITY_SOME_REROUTES\020\016\022\035\n\031PRIOR" +
       "ITY_LOCAL_TO_EXPRESS\020\017\022\033\n\027PRIORITY_SERVI" +
-      "CE_CHANGE\020\020\022\034\n\030PRIORITY_TRAINS_REROUTED\020",
+      "CE_CHANGE\020\020\022\034\n\030PRIORITY_TRAINS_REROUTED\020" +
       "\021\022\033\n\027PRIORITY_PART_SUSPENDED\020\022\022\035\n\031PRIORI" +
       "TY_MULTIPLE_IMPACTS\020\023\022\026\n\022PRIORITY_SUSPEN" +
-      "DED\020\024\022\023\n\017PRIORITY_BUSING\020\025\"\306\006\n\017NyctBusPr" +
+      "DED\020\024\022\023\n\017PRIORITY_BUSING\020\025\"\314\003\n\017NyctBusPr" +
       "iority\022*\n&NYCT_BUS_PRIORITY_NO_SCHEDULED" +
       "_SERVICE\020\001\022%\n!NYCT_BUS_PRIORITY_SUNDAY_S" +
       "CHEDULE\020\002\022\'\n#NYCT_BUS_PRIORITY_SATURDAY_" +
       "SCHEDULE\020\003\022%\n!NYCT_BUS_PRIORITY_HOLIDAY_" +
       "SERVICE\020\004\022$\n NYCT_BUS_PRIORITY_PLANNED_D" +
       "ETOUR\020\005\022#\n\037NYCT_BUS_PRIORITY_EXTRA_SERVI" +
-      "CE\020\006\022\"\n\036NYCT_BUS_PRIORITY_PLANNED_WORK\020\007",
-      "\022!\n\035NYCT_BUS_PRIORITY_ON_OR_CLOSE\020\010\022!\n\035N" +
-      "YCT_BUS_PRIORITY_SLOW_SPEEDS\020\t\022!\n\035NYCT_B" +
-      "US_PRIORITY_SOME_DELAYS\020\n\022#\n\037NYCT_BUS_PR" +
-      "IORITY_SPECIAL_EVENT\020\013\022&\n\"NYCT_BUS_PRIOR" +
-      "ITY_STATIONS_SKIPPED\020\014\022\034\n\030NYCT_BUS_PRIOR" +
-      "ITY_DELAYS\020\r\022&\n\"NYCT_BUS_PRIORITY_EXPRES" +
-      "S_TO_LOCAL\020\016\022#\n\037NYCT_BUS_PRIORITY_SOME_R" +
-      "EROUTES\020\017\022\034\n\030NYCT_BUS_PRIORITY_DETOUR\020\020\022" +
-      "&\n\"NYCT_BUS_PRIORITY_LOCAL_TO_EXPRESS\020\021\022" +
-      "$\n NYCT_BUS_PRIORITY_SERVICE_CHANGE\020\022\022%\n",
-      "!NYCT_BUS_PRIORITY_TRAINS_REROUTED\020\023\022$\n " +
-      "NYCT_BUS_PRIORITY_PART_SUSPENDED\020\024\022&\n\"NY" +
-      "CT_BUS_PRIORITY_MULTIPLE_IMPACTS\020\025\022\037\n\033NY" +
-      "CT_BUS_PRIORITY_SUSPENDED\020\026:_\n\023mercury_f" +
-      "eed_header\022\034.transit_realtime.FeedHeader" +
-      "\030\351\007 \001(\0132#.transit_realtime.MercuryFeedHe" +
-      "ader:O\n\rmercury_alert\022\027.transit_realtime" +
-      ".Alert\030\351\007 \001(\0132\036.transit_realtime.Mercury" +
-      "Alert:k\n\027mercury_entity_selector\022 .trans" +
-      "it_realtime.EntitySelector\030\351\007 \001(\0132\'.tran",
-      "sit_realtime.MercuryEntitySelectorB\035\n\033co" +
-      "m.google.transit.realtime"
+      "CE\020\006\022\"\n\036NYCT_BUS_PRIORITY_PLANNED_WORK\020\007" +
+      "\022#\n\037NYCT_BUS_PRIORITY_SPECIAL_EVENT\020\013\022\034\n" +
+      "\030NYCT_BUS_PRIORITY_DELAYS\020\r\022\035\n\031NYCT_BUS_" +
+      "PRIORITY_DETOURS\020\020\022$\n NYCT_BUS_PRIORITY_" +
+      "SERVICE_CHANGE\020\022\022\037\n\033NYCT_BUS_PRIORITY_SU" +
+      "SPENDED\020\026:_\n\023mercury_feed_header\022\034.trans" +
+      "it_realtime.FeedHeader\030\351\007 \001(\0132#.transit_" +
+      "realtime.MercuryFeedHeader:O\n\rmercury_al" +
+      "ert\022\027.transit_realtime.Alert\030\351\007 \001(\0132\036.tr" +
+      "ansit_realtime.MercuryAlert:k\n\027mercury_e" +
+      "ntity_selector\022 .transit_realtime.Entity" +
+      "Selector\030\351\007 \001(\0132\'.transit_realtime.Mercu" +
+      "ryEntitySelectorB\035\n\033com.google.transit.r" +
+      "ealtime"
     };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
+    descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.transit.realtime.GtfsRealtime.getDescriptor(),
-        }, assigner);
+        });
     internal_static_transit_realtime_MercuryFeedHeader_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_transit_realtime_MercuryFeedHeader_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_MercuryFeedHeader_descriptor,
         new java.lang.String[] { "MercuryVersion", });
     internal_static_transit_realtime_MercuryAlert_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_transit_realtime_MercuryAlert_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_MercuryAlert_descriptor,
         new java.lang.String[] { "CreatedAt", "UpdatedAt", "AlertType", });
     internal_static_transit_realtime_MercuryEntitySelector_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_transit_realtime_MercuryEntitySelector_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_transit_realtime_MercuryEntitySelector_descriptor,
         new java.lang.String[] { "SortOrder", });
     mercuryFeedHeader.internalInit(descriptor.getExtensions().get(0));


### PR DESCRIPTION
This PR bumps the upstream dependency to `io.mobilitydata.transit:gtfs-realtime-bindings:0.0.5`.

Unfortunately there's a bit of churn along with it because this also bumps the transitive dependency on the Java protobuf runtime from 2.6.1 to 3.6.1, which necessitates re-running `protoc` on the extensions, but the current version of `protoc` is 3.11.4, so we end up having to pull in that version of the protobuf runtime as an explicit dependency instead.